### PR TITLE
Fix #10: double-quote reserved-word field names in read_json_auto STRUCT type

### DIFF
--- a/src/ddb-sql-builder.js
+++ b/src/ddb-sql-builder.js
@@ -324,5 +324,7 @@ export function pathsToSchema(node, isInRoot=true) {
 	} else {
 		sqlType = `JSON${arrayIndicator}`;
 	}
-	return isInRoot ? `${node.value}: '${sqlType}'` : `${node.value} ${sqlType}`
+	// Always double-quote the identifier so FHIR field names that are DuckDB
+	// reserved words (e.g. `end` from Period) produce a valid type spec (issue #10).
+	return isInRoot ? `"${node.value}": '${sqlType}'` : `"${node.value}" ${sqlType}`
 };

--- a/tests/schema.test.js
+++ b/tests/schema.test.js
@@ -35,21 +35,21 @@ describe("fhirpath to duckdb sql schemas", () => {
 	test("string type", async () => {
 		const fp = "id";
 		const schema = buildSchemaSubset(fp, "Observation", fhirSchema);
-		const target = "{id: 'VARCHAR'}";
+		const target = `{ "id": 'VARCHAR' }`;
 		expect(schema.replace(/\s*/g, "")).toEqual(target.replace(/\s*/g, ""));
 	});
 
 	test("integer type", async () => {
 		const fp = "valueInteger";
 		const schema = buildSchemaSubset(fp, "Observation", fhirSchema);
-		const target = "{valueInteger: 'INTEGER'}";
+		const target = `{ "valueInteger": 'INTEGER' }`;
 		expect(schema.replace(/\s*/g, "")).toEqual(target.replace(/\s*/g, ""));
 	});
 
 	test("boolean type", async () => {
 		const fp = "valueBoolean";
 		const schema = buildSchemaSubset(fp, "Observation", fhirSchema);
-		const target = "{valueBoolean: 'BOOLEAN'}";
+		const target = `{ "valueBoolean": 'BOOLEAN' }`;
 		expect(schema.replace(/\s*/g, "")).toEqual(target.replace(/\s*/g, ""));
 	});
 
@@ -57,7 +57,7 @@ describe("fhirpath to duckdb sql schemas", () => {
 		const decimalSchema = {"Custom.valueDecimal": {t: "decimal"}}
 		const fp = "valueDecimal";
 		const schema = buildSchemaSubset(fp, "Custom", decimalSchema);
-		const target = "{valueDecimal: 'DOUBLE'}";
+		const target = `{ "valueDecimal": 'DOUBLE' }`;
 		expect(schema.replace(/\s*/g, "")).toEqual(target.replace(/\s*/g, ""));
 	});
 
@@ -65,49 +65,59 @@ describe("fhirpath to duckdb sql schemas", () => {
 		const customSchema = {"Custom": {t: "custom"}}
 		const fp = "custom";
 		const schema = buildSchemaSubset(fp, "Custom", customSchema);
-		const target = "{custom: 'JSON'}";
+		const target = `{ "custom": 'JSON' }`;
 		expect(schema.replace(/\s*/g, "")).toEqual(target.replace(/\s*/g, ""));
 	});
 
 	test("struct", async () => {
 		const fp = "valueQuantity.value";
 		const schema = buildSchemaSubset(fp, "Observation", fhirSchema);
-		const target = "{valueQuantity: 'STRUCT(value DOUBLE)'}";
+		const target = `{ "valueQuantity": 'STRUCT("value" DOUBLE)' }`;
 		expect(schema.replace(/\s*/g, "")).toEqual(target.replace(/\s*/g, ""));	
 	})
 
 	test("array", async () => {
 		const fp = "name.family";
 		const schema = buildSchemaSubset(fp, "Patient", fhirSchema);
-		const target = "{name: 'STRUCT(family VARCHAR)[]'}"
+		const target = `{ "name": 'STRUCT("family" VARCHAR)[]' }`
 		expect(schema.replace(/\s*/g, "")).toEqual(target.replace(/\s*/g, ""));	
 	});
 
 	test("array of arrays", async () => {
 		const fp = "name.given";
 		const schema = buildSchemaSubset(fp, "Patient", fhirSchema);
-		const target = "{name: 'STRUCT(given VARCHAR[])[]'}"
+		const target = `{ "name": 'STRUCT("given" VARCHAR[])[]' }`
 		expect(schema.replace(/\s*/g, "")).toEqual(target.replace(/\s*/g, ""));	
 	});
 
 	test("multiple paths should be at top level", async () => {
 		const fp = ["name.family", "active"]
 		const schema = buildSchemaSubset(fp, "Patient", fhirSchema);
-		const target = "{name: 'STRUCT(family VARCHAR)[]', active: 'BOOLEAN'}"
+		const target = `{ "name": 'STRUCT("family" VARCHAR)[]', "active": 'BOOLEAN' }`
 		expect(schema.replace(/\s*/g, "")).toEqual(target.replace(/\s*/g, ""));	
 	});
 
 	test("overlapping paths should nest", async () => {
 		const fp = ["name.family", "name.given"]
 		const schema = buildSchemaSubset(fp, "Patient", fhirSchema);
-		const target = "{name: 'STRUCT(family VARCHAR, given VARCHAR[])[]'}"
+		const target = `{ "name": 'STRUCT("family" VARCHAR, "given" VARCHAR[])[]' }`
 		expect(schema.replace(/\s*/g, "")).toEqual(target.replace(/\s*/g, ""));	
 	});
 
 	test("repeated paths should be included once", async () => {
 		const fp = ["name.family", "name.family"]
 		const schema = buildSchemaSubset(fp, "Patient", fhirSchema);
-		const target = "{name: 'STRUCT(family VARCHAR)[]'}"
+		const target = `{ "name": 'STRUCT("family" VARCHAR)[]' }`
+		expect(schema.replace(/\s*/g, "")).toEqual(target.replace(/\s*/g, ""));
+	});
+
+	test("reserved-word field names are double-quoted", async () => {
+		// `end` (from FHIR Period) is a DuckDB reserved word; emitting it
+		// unquoted produces an unparseable STRUCT type spec (issue #10).
+		const customSchema = {"Custom.period": {t: "Period"}, "Period.end": {t: "dateTime"}};
+		const fp = "period.end";
+		const schema = buildSchemaSubset(fp, "Custom", customSchema);
+		const target = `{ "period": 'STRUCT("end" VARCHAR)' }`;
 		expect(schema.replace(/\s*/g, "")).toEqual(target.replace(/\s*/g, ""));
 	});
 


### PR DESCRIPTION
Fixes #10.

## Problem
`pathsToSchema` (`src/ddb-sql-builder.js`) emitted FHIR field names **unquoted** in the `read_json_auto` `columns` STRUCT type string. When a field name is a DuckDB reserved word — e.g. `end` from the FHIR `Period` type — the generated spec is unparseable:

```
columns = { period: 'STRUCT(start JSON, end JSON)' }
-> Invalid Input Error: Value "STRUCT(start JSON, end JSON)" can not be converted to a DuckDB Type.
```

## Fix
Always double-quote the identifier in both emitted forms (root key and struct member):

```js
return isInRoot ? `"${node.value}": '${sqlType}'` : `"${node.value}" ${sqlType}`
```

Always-quoting is safe for all names and avoids maintaining a reserved-word list (the issue's recommended direction). Verified in DuckDB 1.5.2 that quoting normal identifiers is harmless, that quoting works for both the root key and struct members, and that the previously-failing `Encounter` `period.start`/`period.end` view now **executes and returns rows** instead of aborting.

## Tests
- Added a reserved-word (`end`) regression test in `tests/schema.test.js`.
- Updated existing schema expectations to the quoted output.
- **All 192 tests pass** (`bun test`), including the e2e tests that run real `read_json_auto` queries.

> Note: the secondary schema-coverage observation in #10 (Period fields falling back to `JSON` instead of `VARCHAR`) is the R4-schema bug fixed separately in #11 — the two compose cleanly. This PR is purely the quoting fix.