### PR TITLE
Fix #9: where() multi-segment predicate crash + exists(<criterion>) ignoring its argument

### DIFF
--- a/src/ddb-sql-builder.js
+++ b/src/ddb-sql-builder.js
@@ -134,14 +134,17 @@ export function astToSql(node, inLambda, inputType={}) {
 					return {sql, outputType: {fhirType: "string", isArray: false}}
 				
 				case 'where':
+					// Compile the whole predicate chain (node.args[0]), not just its
+					// first segment — a multi-segment predicate (e.g. `coding.exists(...)`)
+					// must be walked end-to-end to yield a boolean.
 					if (inputType && inputType.isArray) {
-						sql = `list_filter(el -> ${flattenSql(astToSql(firstArg, true)).sql})`;
+						sql = `list_filter(el -> ${flattenSql(astToSql(node.args[0], true)).sql})`;
 						outputType = {fhirType: inputType.fhirType, isArray: true}
 					} else if (inputType.fhirType) {
-						sql = `as_list().list_filter(el -> ${flattenSql(astToSql(firstArg, true)).sql}).slice(1)`;
+						sql = `as_list().list_filter(el -> ${flattenSql(astToSql(node.args[0], true)).sql}).slice(1)`;
 						outputType = {fhirType: inputType.fhirType, isArray: false}
 					} else {
-						sql = flattenSql(astToSql(firstArg)).sql;			
+						sql = flattenSql(astToSql(node.args[0])).sql;
 						outputType = {fhirType: "boolean_expr", isArray: false}
 					}
 					return {sql, outputType}
@@ -153,9 +156,15 @@ export function astToSql(node, inLambda, inputType={}) {
 					return {sql, outputType: {isArray: false, fhirType: "boolean_expr"}}
 	
 				case 'exists':
+					// exists(criterion) === where(criterion).exists(): when a criterion
+					// is supplied, filter by it instead of by "element is present".
 					if (inputType.isArray) {
-						const sqlExpr = inputType.fhirType == "boolean_expr" ? " = true" : "IS NOT NULL";
-						sql = `list_filter(el -> el ${sqlExpr}).ifnull2([]).len() > 0`					
+						const predicate = node.args[0]
+							? flattenSql(astToSql(node.args[0], true)).sql
+							: `el ${inputType.fhirType == "boolean_expr" ? "= true" : "IS NOT NULL"}`;
+						sql = `list_filter(el -> ${predicate}).ifnull2([]).len() > 0`
+					} else if (node.args[0]) {
+						sql = `as_list().list_filter(el -> ${flattenSql(astToSql(node.args[0], true)).sql}).ifnull2([]).len() > 0`;
 					} else {
 						sql = inputType.fhirType == "boolean_expr" ? "is_true()" : "is_not_null()";
 					}

--- a/tests/fp.test.js
+++ b/tests/fp.test.js
@@ -256,6 +256,74 @@ describe("basic fhirpath to duckdb sql", () => {
 		expect(result).toEqual(target);
 	});
 
+	// exists(<criterion>) must apply its argument. No name has use='fake', so
+	// this must be false (a criterion-ignoring implementation returns true
+	// because some name exists).
+	test("exists on list with criteria matching nothing", async () => {
+		const fp = "name.exists(use='fake')";
+		const resource = multipleNames;
+		const target = false;
+		const query = buildQuery(fp, resource.resourceType, fhirSchema);
+		const result = await testQuery(query, resource);
+		expect(result).toEqual(target);
+	});
+
+	// where() with a multi-segment predicate must compile the whole chain.
+	// `given.exists()` is [seg(given), fn(exists)]; truncating it to `el.given`
+	// (a list, not a boolean) would fail the list_filter lambda. Only the
+	// second name (nickname) has `given`, so family -> ["f2"].
+	test("where with multi-segment predicate", async () => {
+		const fp = "name.where(given.exists()).family";
+		const resource = multipleNames;
+		const target = ["f2"];
+		const query = buildQuery(fp, resource.resourceType, fhirSchema);
+		const result = await testQuery(query, resource);
+		expect(result).toEqual(target);
+	});
+
+	// exists(<criterion>) on a singleton (non-array) input must also apply its
+	// criterion. `code` is a single CodeableConcept that is present, so a
+	// criterion-ignoring implementation would return true regardless.
+	test("exists on a singleton with criteria", async () => {
+		const fp = "code.exists(text='Systolic')";
+		const resource = {resourceType: "Observation", status: "final", code: {text: "Systolic"}};
+		const target = true;
+		const query = buildQuery(fp, resource.resourceType, fhirSchema);
+		const result = await testQuery(query, resource);
+		expect(result).toEqual(target);
+	});
+
+	test("exists on a singleton with criteria matching nothing", async () => {
+		const fp = "code.exists(text='Diastolic')";
+		const resource = {resourceType: "Observation", status: "final", code: {text: "Systolic"}};
+		const target = false;
+		const query = buildQuery(fp, resource.resourceType, fhirSchema);
+		const result = await testQuery(query, resource);
+		expect(result).toEqual(target);
+	});
+
+	// Multi-segment input + compound criterion (the reported scenario): the
+	// where()/exists() chain must walk `code.coding` and apply `system AND code`.
+	test("exists with a compound criterion that matches", async () => {
+		const fp = "code.coding.exists(system='http://loinc.org' and code='8480-6')";
+		const resource = {resourceType: "Observation", status: "final",
+			code: {coding: [{system: "http://loinc.org", code: "8480-6"}]}};
+		const target = true;
+		const query = buildQuery(fp, resource.resourceType, fhirSchema);
+		const result = await testQuery(query, resource);
+		expect(result).toEqual(target);
+	});
+
+	test("exists with a compound criterion that excludes", async () => {
+		const fp = "code.coding.exists(system='http://loinc.org' and code='8480-6')";
+		const resource = {resourceType: "Observation", status: "final",
+			code: {coding: [{system: "http://loinc.org", code: "99999-9"}]}};
+		const target = false;
+		const query = buildQuery(fp, resource.resourceType, fhirSchema);
+		const result = await testQuery(query, resource);
+		expect(result).toEqual(target);
+	});
+
 	test("exists on a non-list", async () => {
 		const fp = "id.exists()";
 		const resource = multipleNames;


### PR DESCRIPTION
Fixes #9.

Two related codegen defects in `src/ddb-sql-builder.js`, both surfacing from a single ViewDefinition (e.g. `code.coding.exists(system='http://loinc.org' and code='85354-9')`).

## Defect #1 — `where()` truncated its predicate to the first segment (the crash)
The `where` case compiled `astToSql(firstArg, …)` where `firstArg = node.args[0][0]` — only the **first segment** of the predicate chain. For a multi-segment predicate like `coding.exists(...)`, this dropped `.exists(...)` and emitted just `el.coding` (a list/struct), so the `list_filter` lambda body wasn't a boolean:

```
Conversion Error: Unimplemented type for cast (... -> BOOLEAN)
```

**Fix:** pass the full argument array `node.args[0]` in all three `where` branches. `astToSql` is built to walk a segment array, and accepts a one-element array, so simple predicates (`where(use='nickname')`) are unaffected.

## Defect #2 — `exists(<criterion>)` ignored its argument (wrong results)
The `exists` case never read `node.args`, so `coding.exists(system=… and code=…)` compiled to "any non-null element exists" and silently discarded the criterion. Per FHIRPath, `exists(criteria) ≡ where(criteria).exists()`.

**Fix:** when `node.args[0]` is present, compile it as the `list_filter` predicate (handled for both array and singleton inputs).

## Interaction
#1 alone stops the crash; #2 is still required for correctness (otherwise the `system`/`code` criteria are ignored). Both are needed.

## Tests (`tests/fp.test.js`, execution-based — the harness runs the SQL)
- **`exists on list with criteria matching nothing`** — `name.exists(use='fake')` → `false` (returned `true` before: criterion ignored).
- **`where with multi-segment predicate`** — `name.where(given.exists()).family` → `["f2"]` (crashed before: `VARCHAR[] -> BOOLEAN`).
- Existing `exists`-with-criterion tests still pass — they were genuinely `true`, and the criterion is now actually evaluated.
- Verified the issue's exact compound-criterion scenario end-to-end (matching Observation → `true`, non-matching → `false`).

**All 193 tests pass.** Per the issue's note, `tests/spec-tests/` (reference-implementation fixtures) were **not** modified; the spec-conformance suite passes unchanged.