### PR TITLE
Fix #16: add strict mode to reject unknown ViewDefinition select directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Additional steps if you would like to run scripts, unit tests or edit the projec
 | `--param` | | | `name=value` pair of user defined variables to be used when generating SQL with a [custom template](#custom-templates). This argument may be repeated. | 
 | `--var` | | | `name=value` pair of FHIRPath variables for use in ViewDefinition expressions (referenced as `%name`). This argument may be repeated. | 
 | `--verbose` | | false | Print debugging information to the console when running FlatQuack. |
+| `--strict` | | false | Reject unsupported/unknown directives on a `select` element (e.g. `repeat`) instead of silently ignoring them. Note: this only validates `select`-element directives — it does not check column-level keys or root-level ViewDefinition keys, so it is not a full schema validation. |
 
 #### Modes (--mode parameter)
 | name | description |

--- a/src/cli.js
+++ b/src/cli.js
@@ -30,6 +30,7 @@ Options:
       --var <name=value>        Values for FHIRPath constants in ViewDefinition (can be repeated)
       --param <name=value>      Template parameters (can be used repeated)
       --verbose                 Enable verbose output
+      --strict                  Reject unsupported/unknown select directives instead of ignoring them
       --help                    Show this help message
       --version                 Show version information
 
@@ -164,6 +165,7 @@ const args = parseArgs({
 		"schema-file": {type: "string", short: "s"},
 		"macros": {type: "string", multiple: true},
 		"verbose": {type: "boolean"},
+		"strict": {type: "boolean"},
 		"mode": {type: "string", short: "m", default: "preview"},
 		"param": {type: "string", multiple: true},
 		"var": {type: "string", multiple: true},
@@ -213,7 +215,7 @@ for (const file of glob.scanSync(args.values["view-path"],{onlyFiles:true})) {
 	const outputPath = path.join(path.dirname(inputPath), basename + ".sql");
 
 	const view = JSON.parse(fs.readFileSync(inputPath));
-	const query = templateToQuery(view, schema, template, params, args.values["verbose"], undefined, customMacros, vars);
+	const query = templateToQuery(view, schema, template, params, args.values["verbose"], undefined, customMacros, vars, args.values["strict"]);
 	const formattedQuery = formatSQL(query);
 
 	if (args.values["mode"] == "build") {

--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -3,8 +3,8 @@ import {astToSql, pathsToSchema, tablesToSql} from "./ddb-sql-builder.js"
 import {parseVd, extractPathsFromAst} from "./view-parser.js";
 import macros from "../templates/duck-macros.js";
 
-export function buildQuery(vd, schema, filterByResourceType, verbose, vars) {
-	const parsedVd = parseVd(vd);
+export function buildQuery(vd, schema, filterByResourceType, verbose, vars, strict) {
+	const parsedVd = parseVd(vd, false, strict);
 	if (verbose) console.log(parsedVd.path)
 
 	const fpAst = fhirpathToAst(parsedVd.path, vd.resource, schema, vars);
@@ -29,13 +29,13 @@ export function buildQuery(vd, schema, filterByResourceType, verbose, vars) {
 }
 
 //TODO: consider replacing this with a full template language
-export function templateToQuery(vd, schema, template, args=[], verbose, filterByResourceType, customMacros=null, vars=null) {
+export function templateToQuery(vd, schema, template, args=[], verbose, filterByResourceType, customMacros=null, vars=null, strict=false) {
 	//Setting filterByResourceType to btrue can only be used if the schema for the
 	//elements being use is compatible between all of the resources being read
 	//(e.g., element with the same names have the same structure). This is used
 	//in some of the tests that mix resource types.
 	
-	const queryParts = buildQuery(vd, schema, filterByResourceType, verbose, vars);
+	const queryParts = buildQuery(vd, schema, filterByResourceType, verbose, vars, strict);
 	const whereSql = queryParts.whereSql ? "WHERE " + queryParts.whereSql : "";
 	const schemaSql = queryParts.schemaSql ? `, columns=${queryParts.schemaSql}` : "";
 

--- a/src/view-parser.js
+++ b/src/view-parser.js
@@ -1,15 +1,24 @@
-//a few quick validation checks
-export function validateVd(vd) {
-	
+//the directives a `select` element may contain (SQL-on-FHIR ViewDefinition)
+const SELECT_KEYS = ["column", "select", "forEach", "forEachOrNull", "unionAll"];
+
+//a few quick validation checks. When `strict` is true, unrecognized directives
+//on a select element are rejected rather than silently ignored.
+export function validateVd(vd, strict) {
+
 	function findSelect(node) {
-		if (node.select) 
+		if (node.select)
 				return true;
 		if (node.unionAll || Array.isArray(node))
 			return (node.unionAll||node).find(findSelect)
 	}
 
-	function validateElement(node) {
+	function validateElement(node, isSelect) {
 		let output = [];
+		if (strict && isSelect) {
+			const unknown = Object.keys(node).find(k => !SELECT_KEYS.includes(k));
+			if (unknown)
+				throw new Error(`unsupported select directive: '${unknown}'`);
+		}
 		if (node.forEach || node.forEachOrNull) {
 			if (node.forEach && typeof(node.forEach) != "string")
 				throw new Error("forEach elements must be a string");
@@ -25,7 +34,7 @@ export function validateVd(vd) {
 		if (node.select) {
 			if (!Array.isArray(node.select))
 				throw new Error("select elements must be an array");
-			output.push( node.select.map(validateElement) );
+			output.push( node.select.map(n => validateElement(n, true)) );
 		}
 
 		if (node.column) {
@@ -43,7 +52,7 @@ export function validateVd(vd) {
 				throw new Error("unionAll elements must be an array");
 			if (findSelect(node.unionAll))
 				throw new Error("Not implemented - nested select in unionAll");
-			const unionItems = node.unionAll.map(u => validateElement(u).flat(Infinity))
+			const unionItems = node.unionAll.map(u => validateElement(u, true).flat(Infinity))
 			const first = JSON.stringify(unionItems[0]);
 			const error = unionItems.slice(1).find(uc => JSON.stringify(uc) != first);
 			if (error) throw new Error("columns in unionAll elements must have matching names");
@@ -66,7 +75,7 @@ export function validateVd(vd) {
 	validateElement(vd);
 }
 
-export function parseVd(vd, skipValidation) {
+export function parseVd(vd, skipValidation, strict) {
 	let tableIndex = 0;
 	let tables = [];
 
@@ -122,7 +131,7 @@ export function parseVd(vd, skipValidation) {
 		return output.join(", ");
 	}
 
-	if (!skipValidation) validateVd(vd);
+	if (!skipValidation) validateVd(vd, strict);
 	const path = parseNode(vd, true);
 	return {path, tables}
 }

--- a/tests/view.test.js
+++ b/tests/view.test.js
@@ -70,6 +70,58 @@ describe("parse view definitions into superpath", () => {
 		expect(result.replace(/\s*/g, "")).toEqual(fp.replace(/\s*/g,""));
 	});
 
+	// An unknown select directive (e.g. `repeat`, which flatquack does not
+	// implement) is silently ignored by default, producing a valid-but-wrong
+	// query. Strict mode (3rd arg) makes validation reject it by name.
+	const repeatView = {
+		resource: "QuestionnaireResponse",
+		select: [
+			{ column: [{ path: "getResourceKey()", name: "id" }] },
+			{ repeat: ["item"], column: [{ path: "linkId", name: "item_link_id" }] }
+		]
+	};
+
+	test("strict mode rejects an unknown select directive", () => {
+		expect(() => parseVd(repeatView, false, true).path).toThrow(/repeat/);
+	});
+
+	test("non-strict mode (default) ignores an unknown select directive", () => {
+		expect(() => parseVd(repeatView).path).not.toThrow();
+	});
+
+	test("strict mode accepts a view using only known directives", () => {
+		const validView = {
+			resource: "Patient",
+			select: [{ forEach: "name", column: [{ name: "family" }] }]
+		};
+		expect(() => parseVd(validView, false, true).path).not.toThrow();
+	});
+
+	// Strict validation is scoped to select-element directives: root-level
+	// ViewDefinition keys (resource, name, where, ...) must not be rejected.
+	test("strict mode does not reject root-level ViewDefinition keys", () => {
+		const view = {
+			resource: "Patient",
+			name: "patient_names",
+			where: [{ path: "active = true" }],
+			select: [{ column: [{ name: "family", path: "name.family" }] }]
+		};
+		expect(() => parseVd(view, false, true).path).not.toThrow();
+	});
+
+	// The strict check must recurse into unionAll (and nested select) elements.
+	test("strict mode rejects an unknown directive inside unionAll", () => {
+		const view = {
+			resource: "Patient",
+			select: [{
+				unionAll: [
+					{ repeat: ["x"], column: [{ name: "family", path: "name.family" }] }
+				]
+			}]
+		};
+		expect(() => parseVd(view, false, true).path).toThrow(/repeat/);
+	});
+
 	test("validation should fail for select in union", () => {
 		const view = {
 			resource: "Observation",


### PR DESCRIPTION
Fixes #16.

## Problem
Unknown directives on a `select` element (e.g. `repeat`, which flatquack doesn't implement) were **silently ignored**. `validateElement` only inspected keys it recognized, so an element with an unknown key *plus* a `column` array passed as an ordinary column block, and `parseNode` dropped the directive entirely — producing a **valid-but-wrong** query (one all-NULL row per resource) instead of failing.

## Fix
Add a `strict` option, **default `false`** (current lenient behavior unchanged), threaded `parseVd → validateVd`, plus a `--strict` CLI flag.

When `strict` is on, `validateElement` rejects any key on a **select element** that isn't a recognized directive (`column`/`select`/`forEach`/`forEachOrNull`/`unionAll`), naming the offender:

```
unsupported select directive: 'repeat'
```

The root ViewDefinition keys (`resource`/`name`/`where`/…) are unaffected — the strict check is applied only to select elements (the root `validateElement(vd)` call is not flagged as a select element).

## Verification
End-to-end via the CLI on the issue's `repeat` view:
- **default:** generates SQL, exit 0 (lenient, unchanged)
- **`--strict`:** `error: unsupported select directive: 'repeat'`

## Tests (`tests/view.test.js`)
- strict mode rejects an unknown directive (`repeat`)
- non-strict (default) ignores it
- strict accepts a view using only known directives

**All 194 tests pass.** `tests/spec-tests/` (reference fixtures) untouched.

> Implementing `repeat` itself remains a separate, larger enhancement; this PR only makes the unsupported subset fail loudly when callers opt in.