### PR TITLE
Stage 2: %rowIndex for forEach / forEachOrNull

### DIFF
--- a/specs/SPEC_hybrid.md
+++ b/specs/SPEC_hybrid.md
@@ -429,31 +429,35 @@ For a `repeat` that is one of **≥2** fan-out siblings, switch that scope to FO
 (§5 repeat): carry the fork key + a descent path through the `WITH RECURSIVE`, and
 join the repeat's scope to its siblings on the fork key.
 
-## 11. `%rowNumber` (positional index for forEach / repeat)
+## 11. `%rowIndex` (positional index for forEach / repeat)
 
-`%rowNumber` is the **1-based positional index of an element within the collection
+`%rowIndex` is the **0-based positional index of an element within the collection
 its operator iterates, scoped to that operator's parent instance** — *not* a global
 `ROW_NUMBER() OVER` over the output (SoF is order-agnostic; the index is structural,
 computed at the unnest/descent step, so it survives `preserve_insertion_order=false`).
 
-The hybrid is already positioned for this: `%rowNumber` **is** the
+The hybrid is already positioned for this: `%rowIndex` **is** the
 `generate_subscripts`/`WITH ORDINALITY` ordinal it mints for fork keys (§4) — just
-surfaced as a column value instead of (or alongside) being used in a key.
+surfaced as a column value (minus 1, since the ordinal is 1-based) instead of (or
+alongside) being used in a key.
 
 ### forEach / forEachOrNull
-The element's ordinal, available in **either** mode at zero extra cost:
+The element's ordinal, available in **either** mode at zero extra cost. The ordinal is
+**1-based**, so `%rowIndex = ord - 1`:
 
 ```sql
 -- CHAIN mode (staged column UNNEST): add WITH ORDINALITY
-FROM {parent}, UNNEST({parent}.arr) WITH ORDINALITY AS t(node, rn)        -- rn = %rowNumber
+FROM {parent}, UNNEST({parent}.arr) WITH ORDINALITY AS t(node, ord)       -- %rowIndex = ord - 1
 
--- FORK / unnest-in-SELECT mode: generate_subscripts zips positionally with unnest
-SELECT generate_subscripts(arr, 1) AS rn, unnest(arr) AS node FROM {parent}
+-- FORK / unnest-in-SELECT mode: generate_subscripts zips positionally with unnest (already 1-based)
+SELECT generate_subscripts(arr, 1) AS ord, unnest(arr) AS node FROM {parent}
 ```
 
-`rn` is `1,2,3…` **per parent row** (it resets automatically — each driving row's
-`arr` starts at 1). For `forEachOrNull`'s empty→NULL row, guard it:
-`CASE WHEN node IS NULL THEN NULL ELSE rn END`. Identical on `JSON[]` and `STRUCT[]`.
+`ord` is `1,2,3…` **per parent row** (it resets automatically — each driving row's
+`arr` starts at 1), so `%rowIndex` is `0,1,2…`. For `forEachOrNull`'s empty→NULL row,
+`%rowIndex` is **0**: a `LEFT JOIN UNNEST` yields no ordinal (`NULL`) for the empty
+collection, so coalesce before subtracting — `COALESCE(ord, 1) - 1` = `0`. Identical on
+`JSON[]` and `STRUCT[]`.
 
 ### repeat
 A `repeat` has no single parent collection, so the index is assigned **at the repeat
@@ -464,24 +468,25 @@ subscripts the scope already carries, §5 repeat). Two rules make it correct and
    scope is recombined with any sibling — then carry the scalar through the join.
    Computing `ROW_NUMBER()` on the *final flattened output* is wrong: a sibling
    cross-product would multiply the rows and inflate the index.
-2. **Partition by the repeat's parent-scope instance**, order by its path:
+2. **Partition by the repeat's parent-scope instance**, order by its path
+   (`ROW_NUMBER()` is 1-based, so `%rowIndex = rn - 1`):
 
    ```sql
-   ROW_NUMBER() OVER (PARTITION BY {parent-scope key} ORDER BY path) AS rn
+   ROW_NUMBER() OVER (PARTITION BY {parent-scope key} ORDER BY path) - 1 AS rn
    ```
    - **root** repeat → parent scope is the resource → `PARTITION BY rid`
    - **nested** repeat → parent scope is the enclosing iterating node → partition by
      that scope's key `(rid, ord₁…ordₖ)`.
 
-   **Use the enclosing scope's own scalar `%rowNumber` as the partition surrogate.**
+   **Use the enclosing scope's own scalar `%rowIndex` as the partition surrogate.**
    A repeat-inside-repeat keys the inner index by `(rid, outer_rn)` — so nested
    repeats *chain* their indices and you never `PARTITION BY` a `LIST`:
    ```sql
-   o_idx AS (   -- outer repeat: rn per resource; also each ancestor's scalar id
-     SELECT …, ROW_NUMBER() OVER (PARTITION BY rid ORDER BY opath) AS outer_rn FROM o),
+   o_idx AS (   -- outer repeat: rn per resource (0-based); also each ancestor's scalar id
+     SELECT …, ROW_NUMBER() OVER (PARTITION BY rid ORDER BY opath) - 1 AS outer_rn FROM o),
    …
    -- inner repeat, carrying outer_rn; its index resets per ancestor:
-   SELECT …, ROW_NUMBER() OVER (PARTITION BY rid, outer_rn ORDER BY ipath) AS inner_rn FROM i
+   SELECT …, ROW_NUMBER() OVER (PARTITION BY rid, outer_rn ORDER BY ipath) - 1 AS inner_rn FROM i
    ```
 
 Order by the **int list** path, never a string path (`'1.2.1'` mis-orders at ≥10
@@ -508,7 +513,7 @@ the index.
 | `unionAll`            | `UNION ALL` of branch pipelines                       | branches keyed by fork key; `JOIN USING(key)`             |
 | `where` / `resource`  | `WHERE BOOL/resourceType` on the stage                | same                                                      |
 | key (`rid`,`ord_i`)   | **none** (no key in a chain)                          | `rid` at `src`; `ord_i` via `generate_subscripts`/`WITH ORDINALITY` on the spine |
-| `%rowNumber` (§11)    | forEach: `WITH ORDINALITY`/`generate_subscripts` ordinal; repeat: `ROW_NUMBER() OVER (PARTITION BY parent-scope key ORDER BY path)` | same (assign at the operator's scope, carry the scalar through joins) |
+| `%rowIndex` (§11)     | forEach: `WITH ORDINALITY`/`generate_subscripts` ordinal `- 1` (0-based); repeat: `ROW_NUMBER() OVER (PARTITION BY parent-scope key ORDER BY path) - 1` | same (assign at the operator's scope, carry the scalar through joins) |
 
 ---
 

--- a/src/ddb-sql-builder.js
+++ b/src/ddb-sql-builder.js
@@ -75,7 +75,6 @@ export function astToSql(node, inLambda, inputType={}, rootVar="el", rowIndexSql
 		case 'rowIndex':
 			return {sql: rowIndexSql, outputType: {fhirType: "integer", isArray: false}};
 
-
 		//and, or, add, subtract, multiply
 		case 'components':
 			const components = node.args.map( c => {
@@ -231,7 +230,7 @@ export function astToSql(node, inLambda, inputType={}, rootVar="el", rowIndexSql
 					
 					// Process additional parameters (skip the first arg which is the macro name)
 					const macroParams = node.args.slice(1).map(argNodes => {
-						const argAst = flattenSql(astToSql(argNodes, false, inputType));
+						const argAst = flattenSql(astToSql(argNodes, false, inputType, rootVar, rowIndexSql));
 						return argAst.sql;
 					}).join(', ');
 					

--- a/src/ddb-sql-builder.js
+++ b/src/ddb-sql-builder.js
@@ -1,4 +1,8 @@
-export function astToSql(node, inLambda, inputType={}, rootVar="el") {
+// `rowIndexSql` carries the SQL for the current `%rowIndex` — the 0-based position within the
+// nearest enclosing iteration. It defaults to "0" (no enclosing iteration: resource root, or a
+// non-iterating projection branch). A `forEach`/`forEachOrNull` stage rebinds it to its
+// per-iteration ordinal minus 1; threaded unchanged through every nested leaf expression.
+export function astToSql(node, inLambda, inputType={}, rootVar="el", rowIndexSql="0") {
 
 	function flattenSql(querySegments) {
 		if (!querySegments) return;
@@ -24,7 +28,7 @@ export function astToSql(node, inLambda, inputType={}, rootVar="el") {
 	if (Array.isArray(node)) {
 		let prevOutputType = inputType;
 		const outputSql = node.map(n => {
-			const query = astToSql(n, inLambda, prevOutputType, rootVar);
+			const query = astToSql(n, inLambda, prevOutputType, rootVar, rowIndexSql);
 			//only treat first element of a navigation array as in lambda (prefixed with 'el')
 			if (inLambda) inLambda = false; 
 			if (query) prevOutputType = query.outputType;
@@ -42,7 +46,7 @@ export function astToSql(node, inLambda, inputType={}, rootVar="el") {
 		case 'expr':
 		case 'paren':
 			const children = Array.isArray(node.children) ? node.children : [node.children];
-			const query = flattenSql( astToSql(children, inLambda, inputType, rootVar) );
+			const query = flattenSql( astToSql(children, inLambda, inputType, rootVar, rowIndexSql) );
 			return {
 				sql: node.segmentType == "paren" ? `(${query.sql})` : query.sql, 
 				outputType: query.outputType
@@ -64,11 +68,18 @@ export function astToSql(node, inLambda, inputType={}, rootVar="el") {
 		case 'literal':
 			sql = node.type.fhirType != "dateTime" ? node.value : `(TIMESTAMP '${node.value.replace("T", " ")}')`
 			return {sql, outputType: {fhirType: node.type.fhirType, isArray: false}};
-		
+
+		// `%rowIndex`: the 0-based position within the nearest enclosing iteration, threaded as
+		// `rowIndexSql` (bound to the iteration ordinal minus 1 by an enclosing forEach/forEachOrNull,
+		// else "0" at the resource root / a non-iterating branch).
+		case 'rowIndex':
+			return {sql: rowIndexSql, outputType: {fhirType: "integer", isArray: false}};
+
+
 		//and, or, add, subtract, multiply
 		case 'components':
 			const components = node.args.map( c => {
-				return flattenSql( astToSql(c, inLambda, {}, rootVar) );
+				return flattenSql( astToSql(c, inLambda, {}, rootVar, rowIndexSql) );
 			});
 			sql = components.map(c => c.sql).join(` ${node.operator} `);
 			outputType = {fhirType: node.type.fhirType == "number" ? "number" : "boolean_expr", isArray: false}
@@ -76,9 +87,9 @@ export function astToSql(node, inLambda, inputType={}, rootVar="el") {
 
 		//equality, inequality
 		case 'comparison':
-			let leftQuery = astToSql(node.args[0], inLambda, inputType, rootVar);
+			let leftQuery = astToSql(node.args[0], inLambda, inputType, rootVar, rowIndexSql);
 			let leftIsArray = leftQuery.at(-1).outputType.isArray
-			let rightQuery = astToSql(node.args[1], inLambda, inputType, rootVar);
+			let rightQuery = astToSql(node.args[1], inLambda, inputType, rootVar, rowIndexSql);
 			let rightIsArray = rightQuery.at(-1).outputType.isArray;
 			if (rightIsArray && !leftIsArray) {
 				[rightQuery, leftQuery] = [leftQuery, rightQuery];
@@ -116,13 +127,13 @@ export function astToSql(node, inLambda, inputType={}, rootVar="el") {
 				
 				case 'where':
 					if (inputType && inputType.isArray) {
-						sql = `list_filter(el -> ${flattenSql(astToSql(firstArg, true, {}, "el")).sql})`;
+						sql = `list_filter(el -> ${flattenSql(astToSql(firstArg, true, {}, "el", rowIndexSql)).sql})`;
 						outputType = {fhirType: inputType.fhirType, isArray: true}
 					} else if (inputType.fhirType) {
-						sql = `as_list().list_filter(el -> ${flattenSql(astToSql(firstArg, true, {}, "el")).sql}).slice(1)`;
+						sql = `as_list().list_filter(el -> ${flattenSql(astToSql(firstArg, true, {}, "el", rowIndexSql)).sql}).slice(1)`;
 						outputType = {fhirType: inputType.fhirType, isArray: false}
 					} else {
-						sql = flattenSql(astToSql(firstArg, undefined, {}, rootVar)).sql;
+						sql = flattenSql(astToSql(firstArg, undefined, {}, rootVar, rowIndexSql)).sql;
 						outputType = {fhirType: "boolean_expr", isArray: false}
 					}
 					return {sql, outputType}
@@ -169,7 +180,7 @@ export function astToSql(node, inLambda, inputType={}, rootVar="el") {
 				case '_col_collection':
 					const colName = firstArg.value;
 					const colValue = node.args[1].at(-1);
-					let colValueSql = flattenSql(astToSql(node.args[1], inLambda, inputType, rootVar));
+					let colValueSql = flattenSql(astToSql(node.args[1], inLambda, inputType, rootVar, rowIndexSql));
 					
 					// This validation can only really be run at runtime since a collection that happens
 					// to have one value is treated as a non-collection and doesn't need the collection tag. 

--- a/src/fhirpath-parser.js
+++ b/src/fhirpath-parser.js
@@ -201,12 +201,12 @@ function simplifyFhirPath(node, type = null, schema = {}, vars = {}) {
 		case 'ExternalConstant':
 			const varName = node.children[0].terminalNodeText[0].replace(/`/g, '');
 
-			// `%rowIndex` is a SQL-on-FHIR built-in (a per-row ordinal supplied by the engine,
-			// not a user-defined constant). The staged backend does not implement it yet, so
-			// reject it explicitly rather than falling through to the generic "define it with
-			// --var" hint below — a constant `--var` cannot supply a per-row index.
+			// `%rowIndex` is a SQL-on-FHIR built-in: the 0-based position of an element within the
+			// collection its enclosing operator iterates, supplied by the engine per iteration (not a
+			// user-defined `--var`). Emit a dedicated segment the staged emitter resolves to the
+			// per-iteration ordinal; do NOT route it through the `vars` lookup below.
 			if (varName === "rowIndex")
-				throw new Error("`%rowIndex` is not supported by the staged backend yet");
+				return [{ segmentType: "rowIndex", type: { fhirType: "integer", isArray: false } }];
 
 			const varValue = vars[varName];
 

--- a/src/staged-sql-builder.js
+++ b/src/staged-sql-builder.js
@@ -60,9 +60,12 @@ function columnOrder(node) {
 
 export function makeBuilder(schema, vars) {
 
+	// `elem.rowIndexSql` is the SQL the current scope binds `%rowIndex` to: the per-iteration
+	// ordinal of the enclosing forEach/forEachOrNull (0-based), or "0" at the resource root / a
+	// non-iterating scope. Threaded into the leaf engine so a `%rowIndex` leaf resolves to it.
 	function compilePath(pathStr, elem) {
 		const ast = fhirpathToAst(pathStr, elem.seed, schema, vars);
-		const out = astToSql(ast, elem.inLambda, elem.inputType, elem.ref || "el");
+		const out = astToSql(ast, elem.inLambda, elem.inputType, elem.ref || "el", elem.rowIndexSql || "0");
 		return {sql: out.sql, outputType: out.outputType, type: ast.type};
 	}
 
@@ -70,7 +73,7 @@ export function makeBuilder(schema, vars) {
 		const pathExpr = col.path || col.name;
 		const fpStr = `_col${col.collection ? "_collection" : ""}('${col.name}', ${pathExpr})`;
 		const ast = fhirpathToAst(fpStr, elem.seed, schema, vars);
-		const out = astToSql(ast, elem.inLambda, elem.inputType, elem.ref || "el");
+		const out = astToSql(ast, elem.inLambda, elem.inputType, elem.ref || "el", elem.rowIndexSql || "0");
 		const expr = out.sql.replace(new RegExp(`^'${col.name}':\\s*`), "");
 		return {name: col.name, expr, sql: `${expr} AS ${col.name}`};
 	}
@@ -185,9 +188,12 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 			// CHAIN
 			if (realFanouts.length === 1) {
 				const f = realFanouts[0];
-				const ordName = f.needsOrd ? `ord${keyCols.length}` : null;
-				const childKey = ordName ? [...keyCols, ordName] : keyCols;
+				// A fork-key ordinal (`ord{depth}`, carried as a key column) doubles as this
+				// iteration's `%rowIndex` source; otherwise a private `rn{n}` ordinal supplies it.
+				const ordName = f.needsOrd ? `ord${keyCols.length}` : `rn${++counter}`;
+				const childKey = f.needsOrd ? [...keyCols, ordName] : keyCols;
 				const from = unnestFrom(relName, f, ordName);
+				bindRowIndex(f, ordName);
 				return emitScope(f.node, f.childElem, carriedAfter, childKey, from, false);
 			}
 			// sole unionAll
@@ -197,7 +203,9 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 		// FORK
 		const branches = [];
 		realFanouts.forEach(f => {
-			const from = unnestFrom(relName, f, null);
+			const ordName = `rn${++counter}`;
+			const from = unnestFrom(relName, f, ordName);
+			bindRowIndex(f, ordName);
 			const br = emitScope(f.node, f.childElem, [], keyCols, from, false);
 			branches.push({rel: br.rel, cols: br.cols, kind: f.orNull ? "LEFT" : "INNER"});
 		});
@@ -229,6 +237,17 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 		return orNull
 			? `${rel}\n  LEFT JOIN UNNEST(${rel}.${arrCol})${ordinality} AS ${tuple} ON TRUE`
 			: `${rel}, UNNEST(${rel}.${arrCol})${ordinality} AS ${tuple}`;
+	}
+
+	// Bind this fan-out's `%rowIndex` for the child scope: the 1-based UNNEST ordinal `ordName`
+	// minus 1 (0-based, per SoF). For a `forEachOrNull` whose collection is empty, the LEFT JOIN
+	// supplies one row whose ordinal is NULL — the official fixture wants `%rowIndex = 0` there (the
+	// position of the single produced row), so coalesce the missing ordinal to 1 before subtracting.
+	// Resolved in the child stage, where the ordinal column is in scope. Cast to INTEGER: `WITH
+	// ORDINALITY` yields a BIGINT, but `%rowIndex` is a FHIR `integer`.
+	function bindRowIndex(f, ordName) {
+		const ord = f.orNull ? `COALESCE(${ordName}, 1)` : ordName;
+		f.childElem.rowIndexSql = `CAST(${ord} - 1 AS INTEGER)`;
 	}
 
 	// build a FROM clause that unnests a materialised array column of `relName`
@@ -268,7 +287,11 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 			entries.forEach(e => {
 				if (e.nested) { collect(e.nested, srcRel); return; }
 				if (e.arrCol) {
-					const join = unnestClause(srcRel, e.arrCol, `_b${++counter}`, e.orNull, null);
+					// Each iterating unionAll branch gets its own `%rowIndex` ordinal (resets per
+					// branch), exactly like a forEach/forEachOrNull elsewhere.
+					const ordName = `rn${++counter}`;
+					const join = unnestClause(srcRel, e.arrCol, `_b${++counter}`, e.orNull, ordName);
+					bindRowIndex(e, ordName);
 					const colProjs = (e.node.column || []).map(c => B.compileColumn(c, e.childElem));
 					cols = cols || colProjs.map(c => c.name);
 					const sel = [...keyCols, ...carried, ...colProjs.map(c => c.sql)];

--- a/src/staged-sql-builder.js
+++ b/src/staged-sql-builder.js
@@ -65,7 +65,7 @@ export function makeBuilder(schema, vars) {
 	// non-iterating scope. Threaded into the leaf engine so a `%rowIndex` leaf resolves to it.
 	function compilePath(pathStr, elem) {
 		const ast = fhirpathToAst(pathStr, elem.seed, schema, vars);
-		const out = astToSql(ast, elem.inLambda, elem.inputType, elem.ref || "el", elem.rowIndexSql || "0");
+		const out = astToSql(ast, elem.inLambda, elem.inputType, elem.ref || "el", elem.rowIndexSql);
 		return {sql: out.sql, outputType: out.outputType, type: ast.type};
 	}
 
@@ -73,7 +73,7 @@ export function makeBuilder(schema, vars) {
 		const pathExpr = col.path || col.name;
 		const fpStr = `_col${col.collection ? "_collection" : ""}('${col.name}', ${pathExpr})`;
 		const ast = fhirpathToAst(fpStr, elem.seed, schema, vars);
-		const out = astToSql(ast, elem.inLambda, elem.inputType, elem.ref || "el", elem.rowIndexSql || "0");
+		const out = astToSql(ast, elem.inLambda, elem.inputType, elem.ref || "el", elem.rowIndexSql);
 		const expr = out.sql.replace(new RegExp(`^'${col.name}':\\s*`), "");
 		return {name: col.name, expr, sql: `${expr} AS ${col.name}`};
 	}
@@ -189,11 +189,10 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 			if (realFanouts.length === 1) {
 				const f = realFanouts[0];
 				// A fork-key ordinal (`ord{depth}`, carried as a key column) doubles as this
-				// iteration's `%rowIndex` source; otherwise a private `rn{n}` ordinal supplies it.
-				const ordName = f.needsOrd ? `ord${keyCols.length}` : `rn${++counter}`;
+				// iteration's `%rowIndex` source; otherwise a private ordinal supplies it.
+				const ordName = f.needsOrd ? `ord${keyCols.length}` : name("rn");
 				const childKey = f.needsOrd ? [...keyCols, ordName] : keyCols;
 				const from = unnestFrom(relName, f, ordName);
-				bindRowIndex(f, ordName);
 				return emitScope(f.node, f.childElem, carriedAfter, childKey, from, false);
 			}
 			// sole unionAll
@@ -203,9 +202,7 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 		// FORK
 		const branches = [];
 		realFanouts.forEach(f => {
-			const ordName = `rn${++counter}`;
-			const from = unnestFrom(relName, f, ordName);
-			bindRowIndex(f, ordName);
+			const from = unnestFrom(relName, f, name("rn"));
 			const br = emitScope(f.node, f.childElem, [], keyCols, from, false);
 			branches.push({rel: br.rel, cols: br.cols, kind: f.orNull ? "LEFT" : "INNER"});
 		});
@@ -250,8 +247,11 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 		f.childElem.rowIndexSql = `CAST(${ord} - 1 AS INTEGER)`;
 	}
 
-	// build a FROM clause that unnests a materialised array column of `relName`
+	// Build a FROM clause that unnests a materialised array column of `relName` with `WITH
+	// ORDINALITY`, binding the ordinal as `ordName`, and bind the child scope's `%rowIndex` to it.
+	// Single source for chain, fork, and unionAll fan-outs.
 	function unnestFrom(relName, f, ordName) {
+		bindRowIndex(f, ordName);
 		return unnestClause(relName, f.arrCol, `_u${++counter}`, f.orNull, ordName);
 	}
 
@@ -289,9 +289,7 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 				if (e.arrCol) {
 					// Each iterating unionAll branch gets its own `%rowIndex` ordinal (resets per
 					// branch), exactly like a forEach/forEachOrNull elsewhere.
-					const ordName = `rn${++counter}`;
-					const join = unnestClause(srcRel, e.arrCol, `_b${++counter}`, e.orNull, ordName);
-					bindRowIndex(e, ordName);
+					const join = unnestFrom(srcRel, e, name("rn"));
 					const colProjs = (e.node.column || []).map(c => B.compileColumn(c, e.childElem));
 					cols = cols || colProjs.map(c => c.name);
 					const sel = [...keyCols, ...carried, ...colProjs.map(c => c.sql)];

--- a/tests/spec-tests/row_index.json
+++ b/tests/spec-tests/row_index.json
@@ -1,0 +1,643 @@
+{
+  "title": "row_index",
+  "description": "%rowIndex environment variable for tracking element positions during iteration",
+  "fhirVersion": ["5.0.0", "4.0.1", "3.0.2"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "pt1",
+      "name": [
+        {
+          "family": "Smith",
+          "given": ["John", "James"]
+        },
+        {
+          "family": "Jones",
+          "given": ["Jane"]
+        }
+      ],
+      "contact": [
+        {
+          "name": {
+            "family": "Contact1"
+          },
+          "telecom": [
+            {
+              "system": "phone",
+              "value": "111-1111"
+            },
+            {
+              "system": "email",
+              "value": "a@example.com"
+            }
+          ]
+        },
+        {
+          "name": {
+            "family": "Contact2"
+          },
+          "telecom": [
+            {
+              "system": "phone",
+              "value": "222-2222"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt2",
+      "name": [
+        {
+          "family": "Brown"
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt3"
+    },
+    {
+      "resourceType": "QuestionnaireResponse",
+      "id": "qr1",
+      "questionnaire": "http://example.com/Questionnaire/q1",
+      "status": "completed",
+      "item": [
+        {
+          "linkId": "1",
+          "text": "Group 1",
+          "item": [
+            {
+              "linkId": "1.1",
+              "text": "Question 1.1"
+            },
+            {
+              "linkId": "1.2",
+              "text": "Question 1.2"
+            }
+          ]
+        },
+        {
+          "linkId": "2",
+          "text": "Group 2"
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "title": "%rowIndex at top level",
+      "description": "At the resource level (no forEach), %rowIndex is 0 for each resource",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "row_index",
+                "path": "%rowIndex",
+                "type": "integer"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "row_index": 0
+        },
+        {
+          "id": "pt2",
+          "row_index": 0
+        },
+        {
+          "id": "pt3",
+          "row_index": 0
+        }
+      ]
+    },
+    {
+      "title": "%rowIndex with forEach",
+      "description": "Returns the 0-based index of each element in the iterated collection",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEach": "name",
+            "column": [
+              {
+                "name": "name_index",
+                "path": "%rowIndex",
+                "type": "integer"
+              },
+              {
+                "name": "family",
+                "path": "family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "name_index": 0,
+          "family": "Smith"
+        },
+        {
+          "id": "pt1",
+          "name_index": 1,
+          "family": "Jones"
+        },
+        {
+          "id": "pt2",
+          "name_index": 0,
+          "family": "Brown"
+        }
+      ]
+    },
+    {
+      "title": "%rowIndex with forEachOrNull",
+      "description": "Returns the 0-based index; for empty collections, returns 0 for the null row",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEachOrNull": "name",
+            "column": [
+              {
+                "name": "name_index",
+                "path": "%rowIndex",
+                "type": "integer"
+              },
+              {
+                "name": "family",
+                "path": "family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "name_index": 0,
+          "family": "Smith"
+        },
+        {
+          "id": "pt1",
+          "name_index": 1,
+          "family": "Jones"
+        },
+        {
+          "id": "pt2",
+          "name_index": 0,
+          "family": "Brown"
+        },
+        {
+          "id": "pt3",
+          "name_index": 0,
+          "family": null
+        }
+      ]
+    },
+    {
+      "title": "%rowIndex with nested forEach",
+      "description": "Each nesting level has its own independent %rowIndex value",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEach": "contact",
+            "column": [
+              {
+                "name": "contact_index",
+                "path": "%rowIndex",
+                "type": "integer"
+              },
+              {
+                "name": "contact_family",
+                "path": "name.family",
+                "type": "string"
+              }
+            ],
+            "select": [
+              {
+                "forEach": "telecom",
+                "column": [
+                  {
+                    "name": "telecom_index",
+                    "path": "%rowIndex",
+                    "type": "integer"
+                  },
+                  {
+                    "name": "system",
+                    "path": "system",
+                    "type": "code"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "contact_index": 0,
+          "contact_family": "Contact1",
+          "telecom_index": 0,
+          "system": "phone"
+        },
+        {
+          "id": "pt1",
+          "contact_index": 0,
+          "contact_family": "Contact1",
+          "telecom_index": 1,
+          "system": "email"
+        },
+        {
+          "id": "pt1",
+          "contact_index": 1,
+          "contact_family": "Contact2",
+          "telecom_index": 0,
+          "system": "phone"
+        }
+      ]
+    },
+    {
+      "title": "%rowIndex with unionAll",
+      "description": "Each branch of unionAll maintains its own %rowIndex sequence",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "unionAll": [
+              {
+                "forEach": "name",
+                "column": [
+                  {
+                    "name": "index",
+                    "path": "%rowIndex",
+                    "type": "integer"
+                  },
+                  {
+                    "name": "value",
+                    "path": "family",
+                    "type": "string"
+                  },
+                  {
+                    "name": "source",
+                    "path": "'name'",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "forEach": "contact",
+                "column": [
+                  {
+                    "name": "index",
+                    "path": "%rowIndex",
+                    "type": "integer"
+                  },
+                  {
+                    "name": "value",
+                    "path": "name.family",
+                    "type": "string"
+                  },
+                  {
+                    "name": "source",
+                    "path": "'contact'",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "index": 0,
+          "value": "Smith",
+          "source": "name"
+        },
+        {
+          "id": "pt1",
+          "index": 1,
+          "value": "Jones",
+          "source": "name"
+        },
+        {
+          "id": "pt1",
+          "index": 0,
+          "value": "Contact1",
+          "source": "contact"
+        },
+        {
+          "id": "pt1",
+          "index": 1,
+          "value": "Contact2",
+          "source": "contact"
+        },
+        {
+          "id": "pt2",
+          "index": 0,
+          "value": "Brown",
+          "source": "name"
+        }
+      ]
+    },
+    {
+      "title": "%rowIndex in unionAll without forEach",
+      "description": "When a unionAll branch has no iteration expression, %rowIndex inherits from the enclosing context",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "unionAll": [
+              {
+                "column": [
+                  {
+                    "name": "id",
+                    "path": "id",
+                    "type": "id"
+                  },
+                  {
+                    "name": "row_index",
+                    "path": "%rowIndex",
+                    "type": "integer"
+                  },
+                  {
+                    "name": "source",
+                    "path": "'a'",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "column": [
+                  {
+                    "name": "id",
+                    "path": "id",
+                    "type": "id"
+                  },
+                  {
+                    "name": "row_index",
+                    "path": "%rowIndex",
+                    "type": "integer"
+                  },
+                  {
+                    "name": "source",
+                    "path": "'b'",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "row_index": 0,
+          "source": "a"
+        },
+        {
+          "id": "pt2",
+          "row_index": 0,
+          "source": "a"
+        },
+        {
+          "id": "pt3",
+          "row_index": 0,
+          "source": "a"
+        },
+        {
+          "id": "pt1",
+          "row_index": 0,
+          "source": "b"
+        },
+        {
+          "id": "pt2",
+          "row_index": 0,
+          "source": "b"
+        },
+        {
+          "id": "pt3",
+          "row_index": 0,
+          "source": "b"
+        }
+      ]
+    },
+    {
+      "title": "%rowIndex in unionAll inside forEach",
+      "description": "Branches with iteration get independent %rowIndex; branches without inherit from the enclosing forEach",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEach": "contact",
+            "column": [
+              {
+                "name": "contact_index",
+                "path": "%rowIndex",
+                "type": "integer"
+              }
+            ],
+            "select": [
+              {
+                "unionAll": [
+                  {
+                    "forEach": "telecom",
+                    "column": [
+                      {
+                        "name": "telecom_index",
+                        "path": "%rowIndex",
+                        "type": "integer"
+                      },
+                      {
+                        "name": "value",
+                        "path": "value",
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  {
+                    "column": [
+                      {
+                        "name": "telecom_index",
+                        "path": "%rowIndex",
+                        "type": "integer"
+                      },
+                      {
+                        "name": "value",
+                        "path": "name.family",
+                        "type": "string"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "contact_index": 0,
+          "telecom_index": 0,
+          "value": "111-1111"
+        },
+        {
+          "id": "pt1",
+          "contact_index": 0,
+          "telecom_index": 1,
+          "value": "a@example.com"
+        },
+        {
+          "id": "pt1",
+          "contact_index": 0,
+          "telecom_index": 0,
+          "value": "Contact1"
+        },
+        {
+          "id": "pt1",
+          "contact_index": 1,
+          "telecom_index": 0,
+          "value": "222-2222"
+        },
+        {
+          "id": "pt1",
+          "contact_index": 1,
+          "telecom_index": 1,
+          "value": "Contact2"
+        }
+      ]
+    },
+    {
+      "title": "%rowIndex for surrogate key",
+      "description": "Combining resource ID with %rowIndex to create a unique identifier for each row",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEach": "name",
+            "column": [
+              {
+                "name": "name_index",
+                "path": "%rowIndex",
+                "type": "integer"
+              },
+              {
+                "name": "family",
+                "path": "family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "name_index": 0,
+          "family": "Smith"
+        },
+        {
+          "id": "pt1",
+          "name_index": 1,
+          "family": "Jones"
+        },
+        {
+          "id": "pt2",
+          "name_index": 0,
+          "family": "Brown"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/spec.staged.test.js
+++ b/tests/spec.staged.test.js
@@ -11,9 +11,10 @@ import fhirSchema from "../schemas/fhir-schema-r4.json";
 const verbose = process.env.VERBOSE === "1";
 const testDirectory = path.join(import.meta.dir, "./spec-tests/");
 
-// The staged emitter does not yet implement `repeat` or `%rowIndex` (later migration
-// stages). Exclude those suites; everything else is the official reference harness, unchanged.
-const EXCLUDE = /^(repeat|row_index)\./;
+// The staged emitter does not yet implement `repeat` (a later migration stage). Exclude that
+// suite; everything else — including `row_index` (`%rowIndex` for forEach/forEachOrNull/unionAll,
+// this stage) — is the official reference harness, unchanged.
+const EXCLUDE = /^(repeat)\./;
 
 let db;
 
@@ -48,15 +49,6 @@ describe("staged - unsupported directives", () => {
 			{forEach: "item", repeat: ["item"], column: [{name: "l", path: "linkId", type: "string"}]}
 		]};
 		expect(() => buildStagedQuery(view, fhirSchema, {})).toThrow(/repeat/);
-	});
-
-	test("%rowIndex is rejected with a clear, non-misleading error", () => {
-		const view = {resource: "Patient", select: [
-			{column: [{name: "idx", path: "%rowIndex", type: "integer"}]}
-		]};
-		// Must not suggest the (useless) `--var rowIndex=...` workaround; must name the feature.
-		expect(() => buildStagedQuery(view, fhirSchema, {})).toThrow(/rowIndex/);
-		expect(() => buildStagedQuery(view, fhirSchema, {})).not.toThrow(/--var/);
 	});
 });
 


### PR DESCRIPTION
Closes #27. Part of #1.

## Problem
The staged emitter did not implement the `%rowIndex` FHIRPath environment variable - it rejected it outright. `%rowIndex` is the 0-based positional index of an element within the collection its operator iterates, scoped to the parent instance (per `specs/SPEC_hybrid.md` §11) - **not** a global `ROW_NUMBER` over the output.

## Solution
- **`src/fhirpath-parser.js`** - `%rowIndex` now parses to a dedicated `{segmentType:"rowIndex"}` AST segment (replacing the prior "not supported" rejection). It is not routed through the user `--var` lookup.
- **`src/ddb-sql-builder.js`** - `astToSql` threads a `rowIndexSql` binding (5th arg, default `"0"`); a `rowIndex` leaf emits it. `"0"` covers the resource root and any non-iterating branch.
- **`src/staged-sql-builder.js`** - every `forEach` / `forEachOrNull` / iterating `unionAll` fan-out binds a `WITH ORDINALITY` ordinal at its `UNNEST` and sets the child scope's `rowIndexSql` to `CAST(ord - 1 AS INTEGER)` (the ordinal is 1-based BIGINT; `%rowIndex` is a 0-based FHIR `integer`). The ordinal resets per driving row automatically, so the index is per-parent. A `forEachOrNull` over an empty collection yields index **0** (`COALESCE` the LEFT-join's missing ordinal to 1 before subtracting), matching the official fixture.
- **`tests/spec-tests/row_index.json`** - the official `%rowIndex` fixture (root, forEach, forEachOrNull incl. empty, nested forEach, unionAll variants, surrogate key).
- **`tests/spec.staged.test.js`** - `row_index` dropped from the exclude set; the now-obsolete "%rowIndex is rejected" assertion removed (the `repeat` rejection assertion is kept).

## Scope
**forEach / forEachOrNull / unionAll only.** `repeat` remains rejected (Stage 3), and `%rowIndex` over `repeat` is Stage 4. The fixture's `%rowIndex with repeat` sub-test is intentionally omitted from this stage; it returns with Stage 4.

## Verification
- `bun test`: **298 pass / 0 fail** (baseline on the base branch: 283 pass / 0 fail). Net +15 = 8 new `row_index` sub-tests x 2 root-key modes, minus the removed rejection test.
- End-to-end via `bun run ./src/cli.js --mode explore` on real NDJSON:
  - root fork (`forEach name` + `forEachOrNull contact`): per-parent indices `name_index` 0/1, `contact_index` 0/1; a patient with no `contact` yields `contact_index: 0, contact_family: null`.
  - nested `forEach contact` -> `forEach telecom`: each level has an independent index that resets per parent.
  - `forEachOrNull contact` standalone: patients with no contact yield `contact_index: 0` (empty-collection guard), present ones reset 0/1 per parent.

DuckDB stays at `^1.4.1`; `WITH ORDINALITY` is 1.4-valid and the generated SQL runs on the existing binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)