### PR TITLE
Stage 3: repeat operation (staged emitter)

### DIFF
--- a/src/ddb-sql-builder.js
+++ b/src/ddb-sql-builder.js
@@ -71,8 +71,12 @@ export function astToSql(node, inLambda, inputType={}, rootVar="el", rowIndexSql
 
 		// `%rowIndex`: the 0-based position within the nearest enclosing iteration, threaded as
 		// `rowIndexSql` (bound to the iteration ordinal minus 1 by an enclosing forEach/forEachOrNull,
-		// else "0" at the resource root / a non-iterating branch).
+		// else "0" at the resource root / a non-iterating branch). A `null` binding means the scope
+		// cannot supply a position — a `%rowIndex` indexing a `repeat`'s own descent scope (Stage 4,
+		// unsupported); reject it rather than silently emit a constant.
 		case 'rowIndex':
+			if (rowIndexSql == null)
+				throw new Error("%rowIndex referencing a repeat's own descent scope is not supported");
 			return {sql: rowIndexSql, outputType: {fhirType: "integer", isArray: false}};
 
 		//and, or, add, subtract, multiply

--- a/src/ddb-sql-builder.js
+++ b/src/ddb-sql-builder.js
@@ -291,15 +291,13 @@ export function pathsToSchema(node, isInRoot=true) {
 // nodes (notably nested-repeat seeds) become `"JSON[]"`, matching the truncate-at-repeat-seed
 // schema rule and keeping those subtrees raw so they can re-enter `WITH RECURSIVE`.
 export function pathsToJsonStruct(node, isInRoot=true) {
-	if (Array.isArray(node)) {
-		const fields = node.map(n => `${JSON.stringify(n.value)}:${pathsToJsonStruct(n, false)}`).join(",");
-		return `{${fields}}`;
-	}
+	const objOf = nodes => `{${nodes.map(n => `${JSON.stringify(n.value)}:${pathsToJsonStruct(n, false)}`).join(",")}}`;
+	if (Array.isArray(node)) return objOf(node);
 
 	const arr = node.isArray;
 	let typeStr;
 	if (!node.forceJson && node.children && node.children.length) {
-		const inner = `{${node.children.map(c => `${JSON.stringify(c.value)}:${pathsToJsonStruct(c, false)}`).join(",")}}`;
+		const inner = objOf(node.children);
 		typeStr = arr ? `[${inner}]` : inner;
 	} else {
 		const scalar = node.forceJson ? "JSON" : leafSqlType(node);

--- a/src/ddb-sql-builder.js
+++ b/src/ddb-sql-builder.js
@@ -254,25 +254,56 @@ export function astToSql(node, inLambda, inputType={}, rootVar="el", rowIndexSql
 	}
 }
 
+// The scalar SQL type a leaf path node reads as. A non-primitive (uppercase) FHIR type, or a
+// node with no resolved type, falls back to raw JSON.
+function leafSqlType(node) {
+	if (node.fhirType == "decimal") return "DOUBLE";
+	if (["boolean", "integer"].indexOf(node.fhirType) > -1) return node.fhirType.toUpperCase();
+	if (node.fhirType && node.fhirType[0] != node.fhirType[0].toUpperCase()) return "VARCHAR";
+	return "JSON";
+}
+
 export function pathsToSchema(node, isInRoot=true) {
 	if (Array.isArray(node)) {
 		const schema = node.map(n => pathsToSchema(n, isInRoot)).join(", ");
-		return (isInRoot) ? `{ ${schema} }` : schema; 
+		return (isInRoot) ? `{ ${schema} }` : schema;
 	}
 
 	const arrayIndicator = node.isArray ? "[]" : "";
 	let sqlType;
-	if (!node.fhirType) console.log(`${JSON.stringify(node)} is of an unknown type`)
-	if (node.children.length) {
-		sqlType = `STRUCT(${node.children.map(c => pathsToSchema(c, false)).join(", ")})${arrayIndicator}`
-	} else if (node.fhirType == "decimal") {
-		sqlType = `DOUBLE${arrayIndicator}`;
-	} else if (["boolean", "integer"].indexOf(node.fhirType) > -1) {
-		sqlType = `${node.fhirType.toUpperCase()}${arrayIndicator}`;
-	} else if (node.fhirType && node.fhirType[0] != node.fhirType[0].toUpperCase()) {
-		sqlType = `VARCHAR${arrayIndicator}`;
-	} else {
+	// A repeat seed is read as a raw JSON list (a recursive FHIR type is not a finite STRUCT);
+	// it forces JSON regardless of any sibling navigation that would otherwise type it.
+	if (node.forceJson) {
 		sqlType = `JSON${arrayIndicator}`;
+	} else if (node.children.length) {
+		if (!node.fhirType) console.log(`${JSON.stringify(node)} is of an unknown type`)
+		sqlType = `STRUCT(${node.children.map(c => pathsToSchema(c, false)).join(", ")})${arrayIndicator}`
+	} else {
+		if (!node.fhirType) console.log(`${JSON.stringify(node)} is of an unknown type`)
+		sqlType = `${leafSqlType(node)}${arrayIndicator}`;
 	}
 	return isInRoot ? `${node.value}: '${sqlType}'` : `${node.value} ${sqlType}`
+};
+
+// Render a path tree as a `from_json` structure (the JSON-object form `from_json` accepts:
+// objects are `{"f":T,...}`, arrays of objects are `[{...}]`, scalar/JSON leaves are quoted
+// type strings like `"VARCHAR"`, `"VARCHAR[]"`, `"JSON[]"`). Truncated/childless complex
+// nodes (notably nested-repeat seeds) become `"JSON[]"`, matching the truncate-at-repeat-seed
+// schema rule and keeping those subtrees raw so they can re-enter `WITH RECURSIVE`.
+export function pathsToJsonStruct(node, isInRoot=true) {
+	if (Array.isArray(node)) {
+		const fields = node.map(n => `${JSON.stringify(n.value)}:${pathsToJsonStruct(n, false)}`).join(",");
+		return `{${fields}}`;
+	}
+
+	const arr = node.isArray;
+	let typeStr;
+	if (!node.forceJson && node.children && node.children.length) {
+		const inner = `{${node.children.map(c => `${JSON.stringify(c.value)}:${pathsToJsonStruct(c, false)}`).join(",")}}`;
+		typeStr = arr ? `[${inner}]` : inner;
+	} else {
+		const scalar = node.forceJson ? "JSON" : leafSqlType(node);
+		typeStr = JSON.stringify(`${scalar}${arr ? "[]" : ""}`);
+	}
+	return isInRoot ? `{${JSON.stringify(node.value)}:${typeStr}}` : typeStr;
 };

--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -10,13 +10,15 @@ import macros from "../templates/duck-macros.js";
 // re-enters `WITH RECURSIVE`; its body is evaluated typed through a from_json bridge instead.
 function applyForcedJson(tree, paths) {
 	(paths || []).forEach(pathStr => {
-		let level = tree, node = null;
+		let level = tree, node = null, matched = true;
 		for (const seg of pathStr.split(".")) {
 			node = level.find(n => n.value === seg);
-			if (!node) break;
+			if (!node) { matched = false; break; }
 			level = node.children;
 		}
-		if (node) { node.forceJson = true; node.children = []; }
+		// Only force-JSON when the FULL path resolved: a partial match leaves `node` pointing at a
+		// shallower ancestor, and truncating that would corrupt a typed sibling's read schema.
+		if (matched && node) { node.forceJson = true; node.children = []; }
 	});
 }
 

--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -4,6 +4,22 @@ import {validateVd, viewPaths, extractPathsFromAst} from "./view-parser.js";
 import {buildStagedQuery} from "./staged-sql-builder.js";
 import macros from "../templates/duck-macros.js";
 
+// Force the schema tree nodes named by resource-rooted dot paths to read as raw JSON[]
+// (a repeat seed: "repeat wins" over any sibling navigation that would type the field). The
+// recursive FHIR type a repeat descends is not a finite STRUCT, so the seed stays raw JSON[] and
+// re-enters `WITH RECURSIVE`; its body is evaluated typed through a from_json bridge instead.
+function applyForcedJson(tree, paths) {
+	(paths || []).forEach(pathStr => {
+		let level = tree, node = null;
+		for (const seg of pathStr.split(".")) {
+			node = level.find(n => n.value === seg);
+			if (!node) break;
+			level = node.children;
+		}
+		if (node) { node.forceJson = true; node.children = []; }
+	});
+}
+
 export function buildQuery(vd, schema, filterByResourceType, verbose, vars, rootKey="natural") {
 	validateVd(vd);
 
@@ -29,6 +45,8 @@ export function buildQuery(vd, schema, filterByResourceType, verbose, vars, root
 	// need not otherwise reference; include its path in the typed read schema so the key binds.
 	const keyAsts = staged.resourceKeyAst ? [staged.resourceKeyAst] : [];
 	const schemaPaths = extractPathsFromAst({asts: [viewAst].concat(whereAsts).concat(keyAsts)});
+	// A repeat seed reachable through typed navigation must read as raw JSON[] ("repeat wins").
+	applyForcedJson(schemaPaths, staged.forcedJsonPaths);
 	const schemaSql = pathsToSchema(schemaPaths)
 	return {schemaSql, whereSql, staged}
 }
@@ -57,6 +75,8 @@ export function templateToQuery(vd, schema, template, args=[], verbose, filterBy
 		["fq_sql_macros", allMacros],
 		["fq_staged_src", queryParts.staged.srcSelect],
 		["fq_staged_tail", queryParts.staged.tail],
+		["fq_staged_with", queryParts.staged.withKeyword],
+		["fq_staged_macros", queryParts.staged.macros],
 		["fq_staged_src_materialized", queryParts.staged.srcMaterialized ? "MATERIALIZED " : ""]
 	]);
 

--- a/src/repeat-lowering.js
+++ b/src/repeat-lowering.js
@@ -1,0 +1,91 @@
+import {fhirpathToAst} from "./fhirpath-parser.js";
+import {pathsToJsonStruct} from "./ddb-sql-builder.js";
+import {extractPathsFromAst} from "./view-parser.js";
+
+// Backend-agnostic `repeat` lowering helpers for the staged (`WITH RECURSIVE`) emitter. A
+// `repeat` descends ONLY its listed paths, recursively, excluding the seed; the descent runs in
+// JSON (a recursive CTE over a JSON node), while every column/forEach/where is still evaluated
+// typed — the recursion's JSON node is converted per-scope to a typed element with a lenient
+// `from_json` bridge, and the existing leaf engine compiles against it unchanged.
+
+// A listed `repeat` path must be a simple dot-separated traversal of element names; anything
+// using a function/filter/indexer (where()/ofType()/first()/[n]) is rejected (a recursive descent
+// has no well-defined meaning for a filtered path).
+export function assertSimplePath(p) {
+	if (typeof p !== "string" || !/^[A-Za-z][A-Za-z0-9]*(\.[A-Za-z][A-Za-z0-9]*)*$/.test(p))
+		throw new Error(`repeat supports simple traversal paths only; got '${p}'`);
+}
+
+// The JSON descent fold for the recursive leg: re-apply each listed path to a visited JSON
+// node (single step `fhir_list(node -> '$.p')`; multi-step `a.b` flattens through `a`;
+// multiple paths concatenate).
+//   NOTE: inside `list_transform` the lambda is written `lambda x:` (not `x ->`) so the body's
+//   JSON arrow `x -> '$.path'` is unambiguous (else DuckDB raises a Binder Error).
+export function jsonFold(paths, nodeExpr) {
+	const folds = paths.map(p => {
+		const steps = p.split(".");
+		let expr = `fhir_list(${nodeExpr} -> '$.${steps[0]}')`;
+		for (let i = 1; i < steps.length; i++)
+			expr = `list_transform(${expr}, lambda x: fhir_list(x -> '$.${steps[i]}')).flatten()`;
+		return expr;
+	});
+	return folds.length === 1 ? folds[0] : `list_concat(${folds.join(", ")})`;
+}
+
+// The seed array off the enclosing element for a repeat's listed paths: each path is the typed
+// navigation of that path (a repeat seed reads as JSON[]); paths that do not resolve off this
+// element (e.g. `answer.item` off the resource focus) contribute nothing. `B` is the builder
+// handle exposing `compilePath`/`arrayize`.
+export function typedSeed(paths, elem, B) {
+	const parts = [];
+	paths.forEach(p => {
+		let resolved;
+		try { resolved = B.compilePath(p, elem); } catch { return; }
+		if (resolved.type && resolved.type.fhirType) parts.push(B.arrayize(p, elem));
+	});
+	if (!parts.length) return "[]::JSON[]";
+	return parts.length === 1 ? parts[0] : `list_concat(${parts.join(", ")})`;
+}
+
+// A resource-rooted FHIRPath expression covering a repeat body's navigations, rooted at the
+// repeat-scope element. Mirrors `viewPaths` but: it walks the body sans the `repeat` directive,
+// and a nested `repeat` inside the body surfaces ONLY its seed fields (each lands childless, hence
+// raw JSON[]) so the recursive subtype is not expanded into a finite STRUCT — that subtree stays
+// raw and re-enters `WITH RECURSIVE` under its own bridge.
+function repeatBodyPaths(node) {
+	if (node.repeat) {
+		// nested repeat: surface the seed fields only (childless navs -> JSON[])
+		return `_nav(${node.repeat.join(", ")})`;
+	}
+	if (node.forEach || node.forEachOrNull) {
+		const rest = repeatBodyPaths({...node, forEach: undefined, forEachOrNull: undefined});
+		return `${node.forEach || node.forEachOrNull}._nav(${rest})`;
+	}
+	const parts = [];
+	if (node.column) parts.push(...node.column.map(c => c.path || c.name));
+	if (node.select) parts.push(...node.select.map(repeatBodyPaths));
+	if (node.unionAll) parts.push(...node.unionAll.map(repeatBodyPaths));
+	return `_nav(${parts.join(", ")})`;
+}
+
+// The `from_json` structure for a repeat scope: `pathsToJsonStruct` over the scope's
+// column/forEach/where paths, rooted at the scope element, truncated at nested repeat seeds.
+export function repeatStructure(repeatNode, elemSchemaPath, schema, vars) {
+	const body = {column: repeatNode.column, select: repeatNode.select, unionAll: repeatNode.unionAll};
+	const path = repeatBodyPaths(body);
+	const ast = fhirpathToAst(path, elemSchemaPath, schema, vars);
+	const tree = extractPathsFromAst({asts: [ast]});
+	if (!tree.length) return "{}";
+	return pathsToJsonStruct(tree);
+}
+
+// The element produced by iterating `pathStr` from `elem`. `B` exposes `compilePath`.
+export function childElemOf(pathStr, elem, B) {
+	const {type} = B.compilePath(pathStr, elem);
+	return {
+		ref: "node",
+		inLambda: true,
+		seed: type.schemaPath,
+		inputType: {fhirType: type.fhirType, isArray: false, schemaPath: type.schemaPath}
+	};
+}

--- a/src/repeat-lowering.js
+++ b/src/repeat-lowering.js
@@ -1,6 +1,6 @@
 import {fhirpathToAst} from "./fhirpath-parser.js";
 import {pathsToJsonStruct} from "./ddb-sql-builder.js";
-import {extractPathsFromAst} from "./view-parser.js";
+import {extractPathsFromAst, viewPaths} from "./view-parser.js";
 
 // Backend-agnostic `repeat` lowering helpers for the staged (`WITH RECURSIVE`) emitter. A
 // `repeat` descends ONLY its listed paths, recursively, excluding the seed; the descent runs in
@@ -41,38 +41,24 @@ export function typedSeed(paths, elem, B) {
 	paths.forEach(p => {
 		let resolved;
 		try { resolved = B.compilePath(p, elem); } catch { return; }
-		if (resolved.type && resolved.type.fhirType) parts.push(B.arrayize(p, elem));
+		if (!resolved.type || !resolved.type.fhirType) return;
+		// arrayize inline from the single compile result rather than recompiling via B.arrayize.
+		parts.push(resolved.outputType.isArray ? resolved.sql : `as_list(${resolved.sql})`);
 	});
 	if (!parts.length) return "[]::JSON[]";
 	return parts.length === 1 ? parts[0] : `list_concat(${parts.join(", ")})`;
 }
 
-// A resource-rooted FHIRPath expression covering a repeat body's navigations, rooted at the
-// repeat-scope element. Mirrors `viewPaths` but: it walks the body sans the `repeat` directive,
-// and a nested `repeat` inside the body surfaces ONLY its seed fields (each lands childless, hence
-// raw JSON[]) so the recursive subtype is not expanded into a finite STRUCT — that subtree stays
-// raw and re-enters `WITH RECURSIVE` under its own bridge.
-function repeatBodyPaths(node) {
-	if (node.repeat) {
-		// nested repeat: surface the seed fields only (childless navs -> JSON[])
-		return `_nav(${node.repeat.join(", ")})`;
-	}
-	if (node.forEach || node.forEachOrNull) {
-		const rest = repeatBodyPaths({...node, forEach: undefined, forEachOrNull: undefined});
-		return `${node.forEach || node.forEachOrNull}._nav(${rest})`;
-	}
-	const parts = [];
-	if (node.column) parts.push(...node.column.map(c => c.path || c.name));
-	if (node.select) parts.push(...node.select.map(repeatBodyPaths));
-	if (node.unionAll) parts.push(...node.unionAll.map(repeatBodyPaths));
-	return `_nav(${parts.join(", ")})`;
-}
-
 // The `from_json` structure for a repeat scope: `pathsToJsonStruct` over the scope's
-// column/forEach/where paths, rooted at the scope element, truncated at nested repeat seeds.
+// column/forEach/where paths, rooted at the scope element, truncated at nested repeat seeds. The
+// nav-path coverage reuses `viewPaths` (the same walker the read-schema derivation uses): a nested
+// `repeat` surfaces ONLY its seed fields (each lands childless, hence raw JSON[]) so the recursive
+// subtype is not expanded into a finite STRUCT — that subtree stays raw and re-enters
+// `WITH RECURSIVE` under its own bridge. The body is passed with the `repeat` directive stripped so
+// `viewPaths` walks it as a plain scope rooted at the element.
 export function repeatStructure(repeatNode, elemSchemaPath, schema, vars) {
 	const body = {column: repeatNode.column, select: repeatNode.select, unionAll: repeatNode.unionAll};
-	const path = repeatBodyPaths(body);
+	const path = viewPaths(body);
 	const ast = fhirpathToAst(path, elemSchemaPath, schema, vars);
 	const tree = extractPathsFromAst({asts: [ast]});
 	if (!tree.length) return "{}";

--- a/src/staged-sql-builder.js
+++ b/src/staged-sql-builder.js
@@ -181,8 +181,12 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 	const srcMaterialized = viewHasFork && rootKeyMode === "uuid";
 
 	// The typed element produced by a from_json bridge over a JSON node column (bound as BRIDGE_VAR).
+	// `rowIndexSql: null` — a repeat's own descent scope has no positional ordinal (the recursive CTE
+	// has no per-iteration index; `%rowIndex` over a repeat's own scope is Stage 4), so a `%rowIndex`
+	// leaf compiled directly against this element is rejected rather than silently bound to a constant.
+	// A forEach/forEachOrNull *inside* a repeat body rebinds `rowIndexSql` to its real ordinal.
 	function bridgeElem(seed) {
-		return {ref: BRIDGE_VAR, inLambda: true, seed, inputType: {fhirType: "BackboneElement", isArray: false, schemaPath: seed}, rowIndexSql: "0"};
+		return {ref: BRIDGE_VAR, inLambda: true, seed, inputType: {fhirType: "BackboneElement", isArray: false, schemaPath: seed}, rowIndexSql: null};
 	}
 
 	// Prepare a repeat fan-out: validate its paths, resolve the descent element type, and
@@ -207,9 +211,24 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 		const carryProj = (rel) => carryCols.map(c => `${rel}.${c}`);
 		const lead = (cols) => cols.length ? cols.join(", ") + ", " : "";
 
+		// A repeat body that forks (>=2 fan-out children below) needs a per-node identity: the rCTE
+		// otherwise keys every descended node on the carried key columns only (constant per resource
+		// for a CHAIN repeat, the parent fork key for a FORK branch), so the body's fork branches would
+		// recombine via `JOIN USING(keyCols)` and cross-product across ALL nodes of the resource. When
+		// so, carry an integer descent `path` (the per-level `WITH ORDINALITY` ordinals from the seed to
+		// a node) through both legs, then assign a deterministic pre-order index at the bridge
+		// (`ORDER BY path`: `[1] < [1,1] < [1,2] < [2]`). The index is unique per visited node and
+		// survives the fork joins as an extra key column. (This is the same descent key Stage 4 binds
+		// for `%rowIndex` over a repeat's own scope; here it is purely a fork-recombination key.)
+		const needNodeKey = subtreeHasFork(f.node);
+
 		const repName = name("rep");
-		const seedLeg = `SELECT ${lead(carryProj(parentRel))}_s.node AS node\n    FROM ${parentRel}, UNNEST(${parentRel}.${f.seedCol}) AS _s(node)`;
-		const recLeg = `SELECT ${lead(carryProj(repName))}_r.node\n    FROM ${repName}, UNNEST(${jsonFold(f.listedPaths, `${repName}.node`)}) AS _r(node)`;
+		const seedPath = needNodeKey ? `[ord]::BIGINT[] AS path, ` : "";
+		const recPath = needNodeKey ? `list_append(${repName}.path, ord), ` : "";
+		const seedOrd = needNodeKey ? ` WITH ORDINALITY AS _s(node, ord)` : ` AS _s(node)`;
+		const recOrd = needNodeKey ? ` WITH ORDINALITY AS _r(node, ord)` : ` AS _r(node)`;
+		const seedLeg = `SELECT ${lead(carryProj(parentRel))}${seedPath}_s.node AS node\n    FROM ${parentRel}, UNNEST(${parentRel}.${f.seedCol})${seedOrd}`;
+		const recLeg = `SELECT ${lead(carryProj(repName))}${recPath}_r.node\n    FROM ${repName}, UNNEST(${jsonFold(f.listedPaths, `${repName}.node`)})${recOrd}`;
 		ctes.push(`${repName} AS (\n    ${seedLeg}\n    UNION ALL\n    ${recLeg}\n  )`);
 
 		// The descent visits a single canonical element type; convert each visited JSON node to a
@@ -217,11 +236,23 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 		const structure = B.repeatStructure(f.node, f.childElem.seed);
 		const cast = `${castMacroFor(structure, f.childElem.seed)}(node)`;
 		const bridge = name("repb");
-		ctes.push(`${bridge} AS (\n  SELECT ${lead(carryCols)}${cast} AS ${BRIDGE_VAR}\n  FROM ${repName}\n)`);
+		let bodyKeyCols = keyCols;
+		if (needNodeKey) {
+			// `ORDER BY path` is a total, deterministic order within the partition (paths are unique per
+			// node), so the index is reproducible across every reference to the bridge — no MATERIALIZED
+			// needed. `keyCols` always includes the resource key here (a body fork forces a root fork key).
+			const nodeKey = `nord${keyCols.length}`;
+			const part = keyCols.length ? `PARTITION BY ${keyCols.join(", ")} ` : "";
+			const rn = `(row_number() OVER (${part}ORDER BY path) - 1)::INTEGER AS ${nodeKey}`;
+			ctes.push(`${bridge} AS (\n  SELECT ${lead(carryCols)}${rn}, ${cast} AS ${BRIDGE_VAR}\n  FROM ${repName}\n)`);
+			bodyKeyCols = [...keyCols, nodeKey];
+		} else {
+			ctes.push(`${bridge} AS (\n  SELECT ${lead(carryCols)}${cast} AS ${BRIDGE_VAR}\n  FROM ${repName}\n)`);
+		}
 
 		// The body of a repeat is evaluated typed (its element is the from_json `el`); nested
 		// repeat seeds arrive as `el.<field>` JSON[] and re-enter `WITH RECURSIVE`.
-		return emitScope(f.node, bridgeElem(f.childElem.seed), carried, keyCols, bridge, false, null);
+		return emitScope(f.node, bridgeElem(f.childElem.seed), carried, bodyKeyCols, bridge, false, null);
 	}
 
 	// A `forEach` over a field that a sibling `repeat` forces to JSON[] (the shared-field case):

--- a/src/staged-sql-builder.js
+++ b/src/staged-sql-builder.js
@@ -1,27 +1,38 @@
 import {fhirpathToAst} from "./fhirpath-parser.js";
 import {astToSql} from "./ddb-sql-builder.js";
+import {assertSimplePath, jsonFold, typedSeed, repeatStructure, childElemOf} from "./repeat-lowering.js";
 
 // Staged-CTE emitter (SPEC_hybrid). Walks the ViewDefinition tree, classifies each
 // scope CHAIN (<=1 fan-out) or FORK (>=2), and emits staged CTEs. Leaves are compiled
 // by the existing typed FHIRPath engine; the scope element is aliased `node` and passed
 // as the engine's outer root-var so internal `el` lambdas never collide (design D2).
+//
+// `repeat` is the one unbounded-depth directive, so it cannot live on the typed substrate:
+// the descent is performed in JSON (a `WITH RECURSIVE` CTE over a JSON node, SPEC_hybrid §5),
+// while every column/forEach/where is still evaluated typed — the recursion's JSON node is
+// converted per-scope to a typed element with a lenient `from_json` bridge, and the existing leaf
+// engine compiles against it unchanged. The binding mode oscillates: typed scopes read
+// `read_json_auto` columns / `node`; a `repeat` scope reads `el = from_json(node)`.
 
 // --- tree helpers ---------------------------------------------------------
 
-function assertNoRepeat(node) {
-	if (!node || typeof node !== "object") return;
-	if (node.repeat) throw new Error("`repeat` is not supported by the staged backend");
-	(node.select || []).forEach(assertNoRepeat);
-	(node.unionAll || []).forEach(assertNoRepeat);
+// Does the ViewDefinition contain any `repeat`? (forces a leading `WITH RECURSIVE`).
+function hasRepeat(node) {
+	if (!node || typeof node !== "object") return false;
+	if (node.repeat) return true;
+	return (node.select || []).some(hasRepeat) || (node.unionAll || []).some(hasRepeat);
 }
 
 // Collect a scope's direct columns and fan-out children. A nested `select` with no
 // fan-out directive is transparent: its columns and fan-outs merge into this scope.
+// A `repeat` child is a fan-out classified as `{type: "repeat"}`.
 function collectScope(node) {
 	let columns = node.column ? [...node.column] : [];
 	let fanouts = [];
 	(node.select || []).forEach(child => {
-		if (child.forEach || child.forEachOrNull) {
+		if (child.repeat) {
+			fanouts.push({type: "repeat", node: child});
+		} else if (child.forEach || child.forEachOrNull) {
 			fanouts.push({type: "each", node: child});
 		} else {
 			const sub = collectScope(child);
@@ -42,7 +53,7 @@ function subtreeHasFork(node) {
 	if (forkCache.has(node)) return forkCache.get(node);
 	const {fanouts} = collectScope(node);
 	const result = fanouts.length >= 2
-		|| fanouts.some(f => f.type === "each" && subtreeHasFork(f.node));
+		|| fanouts.some(f => (f.type === "each" || f.type === "repeat") && subtreeHasFork(f.node));
 	forkCache.set(node, result);
 	return result;
 }
@@ -78,14 +89,17 @@ export function makeBuilder(schema, vars) {
 		return {name: col.name, expr, sql: `${expr} AS ${col.name}`};
 	}
 
+	// Wrap a non-list path as a 1-element list so it can be UNNESTed. Use the SQL-level
+	// array-ness (outputType), not the FHIR cardinality of the final step: navigation through an
+	// array flattens to a list (e.g. `contact.name`), and an indexer like `telecom[0]` yields a
+	// scalar even though `telecom` is a list.
+	function arrayize(pathStr, elem) {
+		const {sql, outputType} = compilePath(pathStr, elem);
+		return outputType.isArray ? sql : `as_list(${sql})`;
+	}
+
 	// Prepare a fan-out over `pathStr` from `elem` in a single compile pass, returning both the
-	// array SQL to UNNEST and the child scope element. (childElemOf and arrayize used to compile
-	// the same path twice.)
-	//   - arrSql: wrap a non-list path as a 1-element list so it can be UNNESTed. Use the SQL-level
-	//     array-ness (outputType), not the FHIR cardinality of the final step: navigation through an
-	//     array flattens to a list (e.g. `contact.name`), and an indexer like `telecom[0]` yields a
-	//     scalar even though `telecom` is a list.
-	//   - childElem: the element produced by iterating `pathStr`.
+	// array SQL to UNNEST and the child scope element.
 	function prepareFanout(pathStr, elem) {
 		const {sql, outputType, type} = compilePath(pathStr, elem);
 		return {
@@ -99,13 +113,15 @@ export function makeBuilder(schema, vars) {
 		};
 	}
 
-	return {compilePath, compileColumn, prepareFanout};
+	const builder = {compilePath, compileColumn, arrayize, prepareFanout};
+	builder.childElemOf = (pathStr, elem) => childElemOf(pathStr, elem, builder);
+	builder.repeatStructure = (repeatNode, elemSchemaPath) => repeatStructure(repeatNode, elemSchemaPath, schema, vars);
+	return builder;
 }
 
 // --- main entry -----------------------------------------------------------
 
 export function buildStagedQuery(vd, schema, vars, opts = {}) {
-	assertNoRepeat(vd);
 	const B = makeBuilder(schema, vars);
 
 	const rootKeyMode = opts.rootKey || "natural";
@@ -116,17 +132,34 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 	let counter = 0;
 	const name = (base) => `${base}_${++counter}`;
 
+	const viewHasRepeat = hasRepeat(vd);
 	const viewHasFork = subtreeHasFork(vd);
 	const rootKey = viewHasFork ? ["rid"] : [];
 
+	// Cast macros: each distinct `from_json` structure becomes one `fq_cast_*` macro emitted in
+	// the preamble; identical structures (e.g. a repeat's single canonical descent type) share a
+	// macro, so a recursion that visits the same element type at every level pools to one macro.
+	const macroByStructure = new Map();
+	const macroDefs = [];
+	function castMacroFor(structure, schemaPath) {
+		if (macroByStructure.has(structure)) return macroByStructure.get(structure);
+		const base = "fq_cast_" + String(schemaPath || "x").replace(/[^A-Za-z0-9]+/g, "_").toLowerCase();
+		const used = new Set(macroByStructure.values());
+		let nm = base, i = 1;
+		while (used.has(nm)) nm = `${base}_${++i}`;
+		macroByStructure.set(structure, nm);
+		macroDefs.push(`CREATE OR REPLACE MACRO ${nm}(j) AS from_json(j, '${structure}');`);
+		return nm;
+	}
+
+	// Repeat seed fields that must be forced to JSON[] in the typed read schema even when a
+	// sibling navigation would otherwise type them ("repeat wins").
+	const forcedJsonPaths = [];
+
 	// The root `rid` is the recombination key for any root fork. In "natural" mode it is the
-	// resource key, sourced from `getResourceKey()` so that a future change to that function's
-	// definition propagates to the key automatically. NOTE: `getResourceKey()` currently
-	// resolves to the bare `id` (no `ResourceType/` prefix), so the natural key only
-	// disambiguates within a single resource type; mixed-type reads risk a cross-type id
-	// collision at a root fork (see issue #26). In "uuid" mode it is a synthesised per-resource
-	// `uuid()` that requires no id-uniqueness assumption, but whose volatility means `src` must
-	// be materialised so both fork branches observe the same value.
+	// resource key, sourced from `getResourceKey()`. In "uuid" mode it is a synthesised per-resource
+	// `uuid()` that requires no id-uniqueness assumption, but whose volatility means `src` must be
+	// materialised so both fork branches (and a repeat's recursive descent) observe the same value.
 	const rootKeyExpr = rootKeyMode === "uuid"
 		? "uuid()"
 		: B.compilePath("getResourceKey()", {ref: null, inLambda: false, seed: vd.resource, inputType: {}}).sql;
@@ -137,20 +170,90 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 		? fhirpathToAst("getResourceKey()", vd.resource, schema, vars)
 		: null;
 	// "uuid()" is volatile: the source scope must be materialised so it is evaluated exactly
-	// once per resource and both branches join on the same key.
+	// once per resource and all branches join on the same key.
 	const srcMaterialized = viewHasFork && rootKeyMode === "uuid";
+
+	// The typed element produced by a from_json bridge over a JSON node column. The bridge column
+	// is bound as `el_r`, NOT `el`: the typed leaf engine names its internal `list_transform`/
+	// `list_filter` lambda parameter `el`, so a repeat-scope column whose path navigates through an
+	// array (e.g. `answer.value.ofType(string)`) would otherwise shadow the bridge element with the
+	// lambda element and bind the wrong struct. A distinct bridge name keeps the two separate.
+	function bridgeElem(seed) {
+		return {ref: "el_r", inLambda: true, seed, inputType: {fhirType: "BackboneElement", isArray: false, schemaPath: seed}, rowIndexSql: "0"};
+	}
+
+	// Prepare a repeat fan-out: validate its paths, resolve the descent element type, and
+	// materialise the seed array into the owning stage's projection.
+	function prepRepeat(f, elem, schemaPrefix, stageSelect) {
+		f.listedPaths = f.node.repeat;
+		f.listedPaths.forEach(assertSimplePath);
+		f.childElem = B.childElemOf(f.listedPaths[0], elem);
+		f.seedCol = name("a") + "_seed";
+		stageSelect.push(`${typedSeed(f.listedPaths, elem, B)} AS ${f.seedCol}`);
+		// A seed field read in a typed scope must be JSON[] even if a sibling forEach types it.
+		if (schemaPrefix) f.listedPaths.forEach(p =>
+			forcedJsonPaths.push([...schemaPrefix, ...p.split(".")].join(".")));
+	}
+
+	// Emit a repeat's JSON descent + typed bridge, then continue the body scope on the typed
+	// element `el`. `parentRel` exposes the materialised seed column + the carried/key columns.
+	// (The descent CTE MUST live under a leading `WITH RECURSIVE`, set up by the caller — a
+	// recursive CTE under a plain `WITH` errors as `Catalog Error: Table 'rep' does not exist`.)
+	function emitRepeat(f, parentRel, carried, keyCols) {
+		const carryCols = [...keyCols, ...carried];
+		const carryProj = (rel) => carryCols.map(c => `${rel}.${c}`);
+		const lead = (cols) => cols.length ? cols.join(", ") + ", " : "";
+
+		const repName = name("rep");
+		const seedLeg = `SELECT ${lead(carryProj(parentRel))}_s.node AS node\n    FROM ${parentRel}, UNNEST(${parentRel}.${f.seedCol}) AS _s(node)`;
+		const recLeg = `SELECT ${lead(carryProj(repName))}_r.node\n    FROM ${repName}, UNNEST(${jsonFold(f.listedPaths, `${repName}.node`)}) AS _r(node)`;
+		ctes.push(`${repName} AS (\n    ${seedLeg}\n    UNION ALL\n    ${recLeg}\n  )`);
+
+		// The descent visits a single canonical element type; convert each visited JSON node to a
+		// typed element with the pooled `from_json` cast macro, then continue the body scope typed.
+		const structure = B.repeatStructure(f.node, f.childElem.seed);
+		const cast = `${castMacroFor(structure, f.childElem.seed)}(node)`;
+		const bridge = name("repb");
+		ctes.push(`${bridge} AS (\n  SELECT ${lead(carryCols)}${cast} AS el_r\n  FROM ${repName}\n)`);
+
+		// The body of a repeat is evaluated typed (its element is the from_json `el`); nested
+		// repeat seeds arrive as `el.<field>` JSON[] and re-enter `WITH RECURSIVE`.
+		return emitScope(f.node, bridgeElem(f.childElem.seed), carried, keyCols, bridge, false, null);
+	}
+
+	// A `forEach` over a field that a sibling `repeat` forces to JSON[] (the shared-field case):
+	// unnest the JSON list and consume each node through the same from_json typed bridge a repeat
+	// scope uses — no recursion, just one descent level.
+	function emitJsonEach(f, parentRel, carried, keyCols, ordName) {
+		const childKey = ordName ? [...keyCols, ordName] : keyCols;
+		const carryCols = [...childKey, ...carried];
+		const from = unnestFrom(parentRel, f, ordName);
+		const structure = B.repeatStructure(f.node, f.childElem.seed);
+		const cast = `${castMacroFor(structure, f.childElem.seed)}(node)`;
+		const bridge = name("repb");
+		ctes.push(`${bridge} AS (\n  SELECT ${carryCols.length ? carryCols.join(", ") + ", " : ""}${cast} AS el_r\n  FROM ${from}\n)`);
+		// `%rowIndex` of this shared-field iteration is bound by unnestFrom (on the bridge element).
+		return emitScope(f.node, bridgeElem(f.childElem.seed), carried, childKey, bridge, false, null);
+	}
 
 	// emitScope: builds a stage exposing keyCols + carried + this scope's columns, then
 	// chains or forks. `fromSql` is the FROM clause for this stage (null at root: the
-	// stage is `src`, whose FROM lives in the template). Returns {rel, cols}.
-	function emitScope(scopeNode, elem, carried, keyCols, fromSql, isRoot) {
+	// stage is `src`, whose FROM lives in the template). `schemaPrefix` (typed scopes only)
+	// is the resource-rooted field path used to mark forced-JSON repeat seeds. Returns {rel, cols}.
+	function emitScope(scopeNode, elem, carried, keyCols, fromSql, isRoot, schemaPrefix) {
 		const {columns, fanouts} = collectScope(scopeNode);
 		const colProjs = columns.map(c => B.compileColumn(c, elem));
 		const carriedAfter = [...carried, ...colProjs.map(c => c.name)];
 
 		const realFanouts = fanouts.filter(f => f.type === "each");
+		const repeatFanouts = fanouts.filter(f => f.type === "repeat");
 		const unionFanouts = fanouts.filter(f => f.type === "union");
-		const total = realFanouts.length + unionFanouts.length;
+		const total = realFanouts.length + repeatFanouts.length + unionFanouts.length;
+
+		// A `forEach` whose field a sibling `repeat` forces to JSON[] must read it via the
+		// from_json bridge rather than as a typed struct array (shared-field case).
+		const repeatSeedFields = new Set(repeatFanouts.flatMap(f => f.node.repeat));
+		realFanouts.forEach(f => { f.jsonMode = repeatSeedFields.has(f.node.forEach || f.node.forEachOrNull); });
 
 		// the root stage defines the resource key; deeper stages carry it forward
 		const keyProj = isRoot
@@ -168,9 +271,11 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 			f.needsOrd = subtreeHasFork(f.node);
 			stageSelect.push(`${arrSql} AS ${f.arrCol}`);
 		});
+		// materialise each repeat's seed array (the JSON descent reads from it)
+		repeatFanouts.forEach(f => prepRepeat(f, elem, schemaPrefix, stageSelect));
 		// materialise arrays needed by unionAll branches
 		unionFanouts.forEach(f => {
-			f.prepared = prepUnion(f.node.unionAll, elem, stageSelect);
+			f.prepared = prepUnion(f.node.unionAll, elem, stageSelect, schemaPrefix);
 		});
 
 		let relName;
@@ -192,8 +297,14 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 				// iteration's `%rowIndex` source; otherwise a private ordinal supplies it.
 				const ordName = f.needsOrd ? `ord${keyCols.length}` : name("rn");
 				const childKey = f.needsOrd ? [...keyCols, ordName] : keyCols;
+				if (f.jsonMode) return emitJsonEach(f, relName, carriedAfter, keyCols, f.needsOrd ? ordName : null);
 				const from = unnestFrom(relName, f, ordName);
-				return emitScope(f.node, f.childElem, carriedAfter, childKey, from, false);
+				const childPrefix = schemaPrefix ? [...schemaPrefix, ...(f.node.forEach || f.node.forEachOrNull).split(".")] : null;
+				return emitScope(f.node, f.childElem, carriedAfter, childKey, from, false, childPrefix);
+			}
+			if (repeatFanouts.length === 1) {
+				// A lone `repeat` is a CHAIN: carry the scope scalars through the rCTE, no key.
+				return emitRepeat(repeatFanouts[0], relName, carriedAfter, keyCols);
 			}
 			// sole unionAll
 			return emitUnion(unionFanouts[0].prepared, relName, carriedAfter, keyCols);
@@ -202,9 +313,20 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 		// FORK
 		const branches = [];
 		realFanouts.forEach(f => {
+			if (f.jsonMode) {
+				const br = emitJsonEach(f, relName, [], keyCols, null);
+				branches.push({rel: br.rel, cols: br.cols, kind: f.orNull ? "LEFT" : "INNER"});
+				return;
+			}
 			const from = unnestFrom(relName, f, name("rn"));
-			const br = emitScope(f.node, f.childElem, [], keyCols, from, false);
+			const br = emitScope(f.node, f.childElem, [], keyCols, from, false, null);
 			branches.push({rel: br.rel, cols: br.cols, kind: f.orNull ? "LEFT" : "INNER"});
+		});
+		repeatFanouts.forEach(f => {
+			// A `repeat` beside >=1 other fan-out is a FORK branch: carry the fork key through the
+			// rCTE and recombine on it (repeat branches are always independent fan-outs, INNER).
+			const br = emitRepeat(f, relName, [], keyCols);
+			branches.push({rel: br.rel, cols: br.cols, kind: "INNER"});
 		});
 		unionFanouts.forEach(f => {
 			const br = emitUnion(f.prepared, relName, [], keyCols);
@@ -256,11 +378,16 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 	}
 
 	// --- unionAll ----------------------------------------------------------
-	// prepUnion materialises each branch's forEach array into the owning stage and
-	// returns a tree describing how to emit the branch pipelines.
-	function prepUnion(unionBranches, elem, stageSelect) {
+	// prepUnion materialises each branch's forEach array (or repeat seed) into the owning
+	// stage and returns a tree describing how to emit the branch pipelines.
+	function prepUnion(unionBranches, elem, stageSelect, schemaPrefix) {
 		return unionBranches.map(b => {
-			if (b.unionAll) return {nested: prepUnion(b.unionAll, elem, stageSelect)};
+			if (b.unionAll) return {nested: prepUnion(b.unionAll, elem, stageSelect, schemaPrefix)};
+			if (b.repeat) {
+				const f = {node: b};
+				prepRepeat(f, elem, schemaPrefix, stageSelect);
+				return {repeat: f};
+			}
 			if (b.forEach || b.forEachOrNull) {
 				const path = b.forEach || b.forEachOrNull;
 				const {arrSql, childElem} = B.prepareFanout(path, elem);
@@ -286,7 +413,14 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 		const collect = (entries, srcRel) => {
 			entries.forEach(e => {
 				if (e.nested) { collect(e.nested, srcRel); return; }
-				if (e.arrCol) {
+				if (e.repeat) {
+					// a repeat branch: descend in JSON, then select its body columns keyed/carried
+					const br = emitRepeat(e.repeat, srcRel, carried, keyCols);
+					const bodyCols = br.cols.slice(carried.length);
+					cols = cols || bodyCols;
+					const sel = [...keyCols, ...carried, ...bodyCols];
+					parts.push(`SELECT ${sel.join(", ")} FROM ${br.rel}`);
+				} else if (e.arrCol) {
 					// Each iterating unionAll branch gets its own `%rowIndex` ordinal (resets per
 					// branch), exactly like a forEach/forEachOrNull elsewhere.
 					const join = unnestFrom(srcRel, e, name("rn"));
@@ -308,12 +442,20 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 		return {rel: uName, cols: [...carried, ...cols]};
 	}
 
-	const rootElem = {ref: null, inLambda: false, seed: vd.resource, inputType: {}};
-	const result = emitScope(vd, rootElem, [], rootKey, null, true);
+	const rootElem = {ref: null, inLambda: false, seed: vd.resource, inputType: {}, rowIndexSql: "0"};
+	const result = emitScope(vd, rootElem, [], rootKey, null, true, []);
 
 	const order = columnOrder(vd);
 	const finalSelect = `SELECT ${order.join(", ")}\nFROM ${result.rel}`;
 	const tail = (ctes.length ? ",\n" + ctes.join(",\n") : "") + "\n" + finalSelect;
 
-	return {srcSelect: emitScope.srcSelect, tail, srcMaterialized, resourceKeyAst};
+	return {
+		srcSelect: emitScope.srcSelect,
+		tail,
+		srcMaterialized,
+		resourceKeyAst,
+		withKeyword: viewHasRepeat ? "WITH RECURSIVE" : "WITH",
+		macros: macroDefs.length ? macroDefs.join("\n") + "\n" : "",
+		forcedJsonPaths
+	};
 }

--- a/src/staged-sql-builder.js
+++ b/src/staged-sql-builder.js
@@ -14,6 +14,13 @@ import {assertSimplePath, jsonFold, typedSeed, repeatStructure, childElemOf} fro
 // engine compiles against it unchanged. The binding mode oscillates: typed scopes read
 // `read_json_auto` columns / `node`; a `repeat` scope reads `el = from_json(node)`.
 
+// The column a repeat's from_json bridge binds its typed element to. Deliberately NOT `el`: the
+// typed leaf engine names its internal `list_transform`/`list_filter` lambda parameter `el`, so a
+// repeat-scope column whose path navigates through an array (e.g. `answer.value.ofType(string)`)
+// would otherwise shadow the bridge element with the lambda element and bind the wrong struct. A
+// distinct bridge name keeps the two separate; it is both the CTE column alias and the leaf root-var.
+const BRIDGE_VAR = "el_r";
+
 // --- tree helpers ---------------------------------------------------------
 
 // Does the ViewDefinition contain any `repeat`? (forces a leading `WITH RECURSIVE`).
@@ -173,13 +180,9 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 	// once per resource and all branches join on the same key.
 	const srcMaterialized = viewHasFork && rootKeyMode === "uuid";
 
-	// The typed element produced by a from_json bridge over a JSON node column. The bridge column
-	// is bound as `el_r`, NOT `el`: the typed leaf engine names its internal `list_transform`/
-	// `list_filter` lambda parameter `el`, so a repeat-scope column whose path navigates through an
-	// array (e.g. `answer.value.ofType(string)`) would otherwise shadow the bridge element with the
-	// lambda element and bind the wrong struct. A distinct bridge name keeps the two separate.
+	// The typed element produced by a from_json bridge over a JSON node column (bound as BRIDGE_VAR).
 	function bridgeElem(seed) {
-		return {ref: "el_r", inLambda: true, seed, inputType: {fhirType: "BackboneElement", isArray: false, schemaPath: seed}, rowIndexSql: "0"};
+		return {ref: BRIDGE_VAR, inLambda: true, seed, inputType: {fhirType: "BackboneElement", isArray: false, schemaPath: seed}, rowIndexSql: "0"};
 	}
 
 	// Prepare a repeat fan-out: validate its paths, resolve the descent element type, and
@@ -214,7 +217,7 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 		const structure = B.repeatStructure(f.node, f.childElem.seed);
 		const cast = `${castMacroFor(structure, f.childElem.seed)}(node)`;
 		const bridge = name("repb");
-		ctes.push(`${bridge} AS (\n  SELECT ${lead(carryCols)}${cast} AS el_r\n  FROM ${repName}\n)`);
+		ctes.push(`${bridge} AS (\n  SELECT ${lead(carryCols)}${cast} AS ${BRIDGE_VAR}\n  FROM ${repName}\n)`);
 
 		// The body of a repeat is evaluated typed (its element is the from_json `el`); nested
 		// repeat seeds arrive as `el.<field>` JSON[] and re-enter `WITH RECURSIVE`.
@@ -231,7 +234,7 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 		const structure = B.repeatStructure(f.node, f.childElem.seed);
 		const cast = `${castMacroFor(structure, f.childElem.seed)}(node)`;
 		const bridge = name("repb");
-		ctes.push(`${bridge} AS (\n  SELECT ${carryCols.length ? carryCols.join(", ") + ", " : ""}${cast} AS el_r\n  FROM ${from}\n)`);
+		ctes.push(`${bridge} AS (\n  SELECT ${carryCols.length ? carryCols.join(", ") + ", " : ""}${cast} AS ${BRIDGE_VAR}\n  FROM ${from}\n)`);
 		// `%rowIndex` of this shared-field iteration is bound by unnestFrom (on the bridge element).
 		return emitScope(f.node, bridgeElem(f.childElem.seed), carried, childKey, bridge, false, null);
 	}

--- a/src/staged-sql-builder.js
+++ b/src/staged-sql-builder.js
@@ -226,17 +226,26 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 
 	// A `forEach` over a field that a sibling `repeat` forces to JSON[] (the shared-field case):
 	// unnest the JSON list and consume each node through the same from_json typed bridge a repeat
-	// scope uses — no recursion, just one descent level.
-	function emitJsonEach(f, parentRel, carried, keyCols, ordName) {
-		const childKey = ordName ? [...keyCols, ordName] : keyCols;
-		const carryCols = [...childKey, ...carried];
+	// scope uses — no recursion, just one descent level. `forkOrd`, when set, carries the iteration
+	// ordinal forward as a recombination key (a fork below needs it); otherwise a private ordinal
+	// supplies this iteration's `%rowIndex` only.
+	function emitJsonEach(f, parentRel, carried, keyCols, forkOrd) {
+		// Mint an ordinal so `%rowIndex` is available even when no fork below needs it as a key —
+		// unnestFrom binds the 0-based `%rowIndex` SQL onto `f.childElem.rowIndexSql` from it.
+		const ordName = forkOrd || name("rn");
+		const childKey = forkOrd ? [...keyCols, ordName] : keyCols;
 		const from = unnestFrom(parentRel, f, ordName);
 		const structure = B.repeatStructure(f.node, f.childElem.seed);
 		const cast = `${castMacroFor(structure, f.childElem.seed)}(node)`;
 		const bridge = name("repb");
-		ctes.push(`${bridge} AS (\n  SELECT ${carryCols.length ? carryCols.join(", ") + ", " : ""}${cast} AS ${BRIDGE_VAR}\n  FROM ${from}\n)`);
-		// `%rowIndex` of this shared-field iteration is bound by unnestFrom (on the bridge element).
-		return emitScope(f.node, bridgeElem(f.childElem.seed), carried, childKey, bridge, false, null);
+		// Project the body element plus the iteration's `%rowIndex` value, so the bridge scope can
+		// bind `%rowIndex` to a column (the raw ordinal is out of scope past this CTE when private).
+		const rnCol = name("jern");
+		const carryCols = [...childKey, ...carried];
+		ctes.push(`${bridge} AS (\n  SELECT ${carryCols.length ? carryCols.join(", ") + ", " : ""}${f.childElem.rowIndexSql} AS ${rnCol}, ${cast} AS ${BRIDGE_VAR}\n  FROM ${from}\n)`);
+		const bodyElem = bridgeElem(f.childElem.seed);
+		bodyElem.rowIndexSql = rnCol;
+		return emitScope(f.node, bodyElem, carried, childKey, bridge, false, null);
 	}
 
 	// emitScope: builds a stage exposing keyCols + carried + this scope's columns, then
@@ -298,9 +307,9 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 				const f = realFanouts[0];
 				// A fork-key ordinal (`ord{depth}`, carried as a key column) doubles as this
 				// iteration's `%rowIndex` source; otherwise a private ordinal supplies it.
+				if (f.jsonMode) return emitJsonEach(f, relName, carriedAfter, keyCols, f.needsOrd ? `ord${keyCols.length}` : null);
 				const ordName = f.needsOrd ? `ord${keyCols.length}` : name("rn");
 				const childKey = f.needsOrd ? [...keyCols, ordName] : keyCols;
-				if (f.jsonMode) return emitJsonEach(f, relName, carriedAfter, keyCols, f.needsOrd ? ordName : null);
 				const from = unnestFrom(relName, f, ordName);
 				const childPrefix = schemaPrefix ? [...schemaPrefix, ...(f.node.forEach || f.node.forEachOrNull).split(".")] : null;
 				return emitScope(f.node, f.childElem, carriedAfter, childKey, from, false, childPrefix);

--- a/src/view-parser.js
+++ b/src/view-parser.js
@@ -96,6 +96,13 @@ export function validateVd(vd) {
 export function viewPaths(vd) {
 
 	function parseNode(node) {
+		// A `repeat` descends its listed paths recursively in JSON; the typed read schema needs
+		// only the seed fields present (the staged emitter forces them to JSON[]), not the body —
+		// the body re-enters typed via a from_json bridge. Surface the seed fields as nav leaves.
+		if (node.repeat) {
+			return `_nav(${node.repeat.join(", ")})`;
+		}
+
 		if (node.forEach || node.forEachOrNull) {
 			const rest = parseNode({...node, forEach: undefined, forEachOrNull: undefined});
 			return `${node.forEach || node.forEachOrNull}._nav(${rest})`;

--- a/templates/csv.sql
+++ b/templates/csv.sql
@@ -1,7 +1,7 @@
 {{fq_sql_macros}}
-
+{{fq_staged_macros}}
 COPY (
-	WITH src AS {{fq_staged_src_materialized}}(
+	{{fq_staged_with}} src AS {{fq_staged_src_materialized}}(
 		SELECT {{fq_staged_src}}
 		FROM read_json_auto(
 			'{{fq_input_dir}}/**/*{{fq_vd_resource}}*.ndjson'

--- a/templates/dbt_model.sql
+++ b/templates/dbt_model.sql
@@ -1,4 +1,5 @@
-WITH src AS {{fq_staged_src_materialized}}(
+{{fq_staged_macros}}
+{{fq_staged_with}} src AS {{fq_staged_src_materialized}}(
 	SELECT {{fq_staged_src}}
 	FROM {{ source('fhir_db', '{{fq_vd_resource}}') }}
 	{{fq_where_filter}}

--- a/templates/duck-macros.js
+++ b/templates/duck-macros.js
@@ -7,4 +7,8 @@ CREATE OR REPLACE MACRO is_true(a) AS a = true;
 CREATE OR REPLACE MACRO is_null(a) AS a IS NULL;
 CREATE OR REPLACE MACRO is_not_null(a) AS a IS NOT NULL;
 CREATE OR REPLACE MACRO as_value(a) AS if(len(a) > 1, error('unexpected collection returned'), a[1]);
+CREATE OR REPLACE MACRO fhir_list(j) AS
+	CASE WHEN j IS NULL THEN []::JSON[]
+	     WHEN json_type(j) = 'ARRAY' THEN json_transform_strict(j, '["JSON"]')
+	     ELSE [j]::JSON[] END;
 `.replace(/^\n|\n$/g, "");

--- a/templates/explore.sql
+++ b/templates/explore.sql
@@ -1,6 +1,6 @@
 {{fq_sql_macros}}
-
-WITH src AS {{fq_staged_src_materialized}}(
+{{fq_staged_macros}}
+{{fq_staged_with}} src AS {{fq_staged_src_materialized}}(
 	SELECT {{fq_staged_src}}
 	FROM read_json_auto(
 		'{{fq_input_dir}}/**/*{{fq_vd_resource}}*.ndjson'

--- a/templates/ndjson.sql
+++ b/templates/ndjson.sql
@@ -1,7 +1,7 @@
 {{fq_sql_macros}}
-
+{{fq_staged_macros}}
 COPY (
-	WITH src AS {{fq_staged_src_materialized}}(
+	{{fq_staged_with}} src AS {{fq_staged_src_materialized}}(
 		SELECT {{fq_staged_src}}
 		FROM read_json_auto(
 			'{{fq_input_dir}}/**/*{{fq_vd_resource}}*.ndjson'

--- a/templates/parquet.sql
+++ b/templates/parquet.sql
@@ -1,7 +1,7 @@
 {{fq_sql_macros}}
-
+{{fq_staged_macros}}
 COPY (
-	WITH src AS {{fq_staged_src_materialized}}(
+	{{fq_staged_with}} src AS {{fq_staged_src_materialized}}(
 		SELECT {{fq_staged_src}}
 		FROM read_json_auto(
 			'{{fq_input_dir}}/**/*{{fq_vd_resource}}*.ndjson'

--- a/tests/spec-tests/repeat.json
+++ b/tests/spec-tests/repeat.json
@@ -1,0 +1,1035 @@
+{
+  "title": "repeat",
+  "description": "Recursive traversal with repeat directive",
+  "fhirVersion": ["5.0.0", "4.0.1", "3.0.2"],
+  "resources": [
+    {
+      "resourceType": "Questionnaire",
+      "id": "q1",
+      "item": [
+        {
+          "linkId": "g1",
+          "text": "Group 1",
+          "type": "group",
+          "item": [
+            {
+              "linkId": "g1.1",
+              "text": "Question 1.1",
+              "type": "string",
+              "item": [
+                {
+                  "linkId": "g1.1.1",
+                  "text": "Sub-question 1.1.1",
+                  "type": "string"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "linkId": "g2",
+          "text": "Group 2",
+          "type": "group"
+        }
+      ]
+    },
+    {
+      "resourceType": "QuestionnaireResponse",
+      "id": "qr1",
+      "item": [
+        {
+          "linkId": "1",
+          "text": "Group 1",
+          "item": [
+            {
+              "linkId": "1.1",
+              "text": "Question 1.1",
+              "answer": [
+                {
+                  "valueString": "Answer 1.1",
+                  "item": [
+                    {
+                      "linkId": "1.1.1",
+                      "text": "Follow-up to 1.1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "linkId": "1.2",
+              "text": "Question 1.2",
+              "item": [
+                {
+                  "linkId": "1.2.1",
+                  "text": "Question 1.2.1"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "linkId": "2",
+          "text": "Group 2"
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "title": "basic",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "QuestionnaireResponse",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "repeat": ["item"],
+            "column": [
+              {
+                "name": "linkId",
+                "path": "linkId",
+                "type": "string"
+              },
+              {
+                "name": "text",
+                "path": "text",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "qr1",
+          "linkId": "1",
+          "text": "Group 1"
+        },
+        {
+          "id": "qr1",
+          "linkId": "1.1",
+          "text": "Question 1.1"
+        },
+        {
+          "id": "qr1",
+          "linkId": "1.2",
+          "text": "Question 1.2"
+        },
+        {
+          "id": "qr1",
+          "linkId": "1.2.1",
+          "text": "Question 1.2.1"
+        },
+        {
+          "id": "qr1",
+          "linkId": "2",
+          "text": "Group 2"
+        }
+      ]
+    },
+    {
+      "title": "item and answer.item",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "QuestionnaireResponse",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "repeat": ["item", "answer.item"],
+            "column": [
+              {
+                "name": "linkId",
+                "path": "linkId",
+                "type": "string"
+              },
+              {
+                "name": "text",
+                "path": "text",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "qr1",
+          "linkId": "1",
+          "text": "Group 1"
+        },
+        {
+          "id": "qr1",
+          "linkId": "1.1",
+          "text": "Question 1.1"
+        },
+        {
+          "id": "qr1",
+          "linkId": "1.1.1",
+          "text": "Follow-up to 1.1"
+        },
+        {
+          "id": "qr1",
+          "linkId": "1.2",
+          "text": "Question 1.2"
+        },
+        {
+          "id": "qr1",
+          "linkId": "1.2.1",
+          "text": "Question 1.2.1"
+        },
+        {
+          "id": "qr1",
+          "linkId": "2",
+          "text": "Group 2"
+        }
+      ]
+    },
+    {
+      "title": "empty expression",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "QuestionnaireResponse",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "repeat": ["jurisdiction"],
+            "column": [
+              {
+                "name": "code",
+                "path": "coding.code",
+                "type": "code"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": []
+    },
+    {
+      "title": "empty child expression",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "QuestionnaireResponse",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "repeat": ["item"],
+            "column": [
+              {
+                "name": "linkId",
+                "path": "linkId",
+                "type": "string"
+              },
+              {
+                "name": "definition",
+                "path": "definition",
+                "type": "uri"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "qr1",
+          "linkId": "1",
+          "definition": null
+        },
+        {
+          "id": "qr1",
+          "linkId": "1.1",
+          "definition": null
+        },
+        {
+          "id": "qr1",
+          "linkId": "1.2",
+          "definition": null
+        },
+        {
+          "id": "qr1",
+          "linkId": "1.2.1",
+          "definition": null
+        },
+        {
+          "id": "qr1",
+          "linkId": "2",
+          "definition": null
+        }
+      ]
+    },
+    {
+      "title": "combined with forEach",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "QuestionnaireResponse",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "repeat": ["item"],
+            "select": [
+              {
+                "column": [
+                  {
+                    "name": "linkId",
+                    "path": "linkId",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "forEach": "answer",
+                "column": [
+                  {
+                    "name": "answerValue",
+                    "path": "value.ofType(string)",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "qr1",
+          "linkId": "1.1",
+          "answerValue": "Answer 1.1"
+        }
+      ]
+    },
+    {
+      "title": "combined with forEachOrNull",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "QuestionnaireResponse",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "repeat": ["item"],
+            "select": [
+              {
+                "column": [
+                  {
+                    "name": "linkId",
+                    "path": "linkId",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "forEachOrNull": "answer",
+                "column": [
+                  {
+                    "name": "answerValue",
+                    "path": "value.ofType(string)",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "qr1",
+          "linkId": "1",
+          "answerValue": null
+        },
+        {
+          "id": "qr1",
+          "linkId": "1.1",
+          "answerValue": "Answer 1.1"
+        },
+        {
+          "id": "qr1",
+          "linkId": "1.2",
+          "answerValue": null
+        },
+        {
+          "id": "qr1",
+          "linkId": "1.2.1",
+          "answerValue": null
+        },
+        {
+          "id": "qr1",
+          "linkId": "2",
+          "answerValue": null
+        }
+      ]
+    },
+    {
+      "title": "combined with unionAll",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "QuestionnaireResponse",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "unionAll": [
+              {
+                "repeat": ["item"],
+                "column": [
+                  {
+                    "name": "type",
+                    "path": "'item'",
+                    "type": "string"
+                  },
+                  {
+                    "name": "linkId",
+                    "path": "linkId",
+                    "type": "string"
+                  },
+                  {
+                    "name": "text",
+                    "path": "text",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "repeat": ["item", "answer.item"],
+                "column": [
+                  {
+                    "name": "type",
+                    "path": "'answer-item'",
+                    "type": "string"
+                  },
+                  {
+                    "name": "linkId",
+                    "path": "linkId",
+                    "type": "string"
+                  },
+                  {
+                    "name": "text",
+                    "path": "text",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "qr1",
+          "type": "item",
+          "linkId": "1",
+          "text": "Group 1"
+        },
+        {
+          "id": "qr1",
+          "type": "item",
+          "linkId": "1.1",
+          "text": "Question 1.1"
+        },
+        {
+          "id": "qr1",
+          "type": "item",
+          "linkId": "1.2",
+          "text": "Question 1.2"
+        },
+        {
+          "id": "qr1",
+          "type": "item",
+          "linkId": "1.2.1",
+          "text": "Question 1.2.1"
+        },
+        {
+          "id": "qr1",
+          "type": "item",
+          "linkId": "2",
+          "text": "Group 2"
+        },
+        {
+          "id": "qr1",
+          "type": "answer-item",
+          "linkId": "1",
+          "text": "Group 1"
+        },
+        {
+          "id": "qr1",
+          "type": "answer-item",
+          "linkId": "1.1",
+          "text": "Question 1.1"
+        },
+        {
+          "id": "qr1",
+          "type": "answer-item",
+          "linkId": "1.1.1",
+          "text": "Follow-up to 1.1"
+        },
+        {
+          "id": "qr1",
+          "type": "answer-item",
+          "linkId": "1.2",
+          "text": "Question 1.2"
+        },
+        {
+          "id": "qr1",
+          "type": "answer-item",
+          "linkId": "1.2.1",
+          "text": "Question 1.2.1"
+        },
+        {
+          "id": "qr1",
+          "type": "answer-item",
+          "linkId": "2",
+          "text": "Group 2"
+        }
+      ]
+    },
+    {
+      "title": "repeat inside forEach",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Questionnaire",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEach": "item",
+            "select": [
+              {
+                "column": [
+                  {
+                    "name": "groupLinkId",
+                    "path": "linkId",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "repeat": ["item"],
+                "column": [
+                  {
+                    "name": "linkId",
+                    "path": "linkId",
+                    "type": "string"
+                  },
+                  {
+                    "name": "text",
+                    "path": "text",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "q1",
+          "groupLinkId": "g1",
+          "linkId": "g1.1",
+          "text": "Question 1.1"
+        },
+        {
+          "id": "q1",
+          "groupLinkId": "g1",
+          "linkId": "g1.1.1",
+          "text": "Sub-question 1.1.1"
+        }
+      ]
+    },
+    {
+      "title": "repeat inside repeat",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Questionnaire",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "repeat": ["item"],
+            "select": [
+              {
+                "column": [
+                  {
+                    "name": "ancestorLinkId",
+                    "path": "linkId",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "repeat": ["item"],
+                "column": [
+                  {
+                    "name": "descendantLinkId",
+                    "path": "linkId",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "q1",
+          "ancestorLinkId": "g1",
+          "descendantLinkId": "g1.1"
+        },
+        {
+          "id": "q1",
+          "ancestorLinkId": "g1",
+          "descendantLinkId": "g1.1.1"
+        },
+        {
+          "id": "q1",
+          "ancestorLinkId": "g1.1",
+          "descendantLinkId": "g1.1.1"
+        }
+      ]
+    },
+    {
+      "title": "repeat inside forEachOrNull",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Questionnaire",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEachOrNull": "item",
+            "select": [
+              {
+                "column": [
+                  {
+                    "name": "groupLinkId",
+                    "path": "linkId",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "repeat": ["item"],
+                "column": [
+                  {
+                    "name": "linkId",
+                    "path": "linkId",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "q1",
+          "groupLinkId": "g1",
+          "linkId": "g1.1"
+        },
+        {
+          "id": "q1",
+          "groupLinkId": "g1",
+          "linkId": "g1.1.1"
+        }
+      ]
+    },
+    {
+      "title": "sibling repeats at top level",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Questionnaire",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "repeat": ["item"],
+            "column": [
+              {
+                "name": "linkIdA",
+                "path": "linkId",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "repeat": ["item"],
+            "column": [
+              {
+                "name": "linkIdB",
+                "path": "linkId",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {"id": "q1", "linkIdA": "g1", "linkIdB": "g1"},
+        {"id": "q1", "linkIdA": "g1", "linkIdB": "g1.1"},
+        {"id": "q1", "linkIdA": "g1", "linkIdB": "g1.1.1"},
+        {"id": "q1", "linkIdA": "g1", "linkIdB": "g2"},
+        {"id": "q1", "linkIdA": "g1.1", "linkIdB": "g1"},
+        {"id": "q1", "linkIdA": "g1.1", "linkIdB": "g1.1"},
+        {"id": "q1", "linkIdA": "g1.1", "linkIdB": "g1.1.1"},
+        {"id": "q1", "linkIdA": "g1.1", "linkIdB": "g2"},
+        {"id": "q1", "linkIdA": "g1.1.1", "linkIdB": "g1"},
+        {"id": "q1", "linkIdA": "g1.1.1", "linkIdB": "g1.1"},
+        {"id": "q1", "linkIdA": "g1.1.1", "linkIdB": "g1.1.1"},
+        {"id": "q1", "linkIdA": "g1.1.1", "linkIdB": "g2"},
+        {"id": "q1", "linkIdA": "g2", "linkIdB": "g1"},
+        {"id": "q1", "linkIdA": "g2", "linkIdB": "g1.1"},
+        {"id": "q1", "linkIdA": "g2", "linkIdB": "g1.1.1"},
+        {"id": "q1", "linkIdA": "g2", "linkIdB": "g2"}
+      ]
+    },
+    {
+      "title": "sibling repeats inside forEach",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Questionnaire",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEach": "item",
+            "select": [
+              {
+                "column": [
+                  {
+                    "name": "groupLinkId",
+                    "path": "linkId",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "repeat": ["item"],
+                "column": [
+                  {
+                    "name": "linkIdA",
+                    "path": "linkId",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "repeat": ["item"],
+                "column": [
+                  {
+                    "name": "linkIdB",
+                    "path": "linkId",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {"id": "q1", "groupLinkId": "g1", "linkIdA": "g1.1", "linkIdB": "g1.1"},
+        {"id": "q1", "groupLinkId": "g1", "linkIdA": "g1.1", "linkIdB": "g1.1.1"},
+        {"id": "q1", "groupLinkId": "g1", "linkIdA": "g1.1.1", "linkIdB": "g1.1"},
+        {"id": "q1", "groupLinkId": "g1", "linkIdA": "g1.1.1", "linkIdB": "g1.1.1"}
+      ]
+    },
+    {
+      "title": "top-level repeat with sibling forEach containing repeat",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Questionnaire",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "repeat": ["item"],
+            "column": [
+              {
+                "name": "topLinkId",
+                "path": "linkId",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "forEach": "item",
+            "select": [
+              {
+                "column": [
+                  {
+                    "name": "groupLinkId",
+                    "path": "linkId",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "repeat": ["item"],
+                "column": [
+                  {
+                    "name": "innerLinkId",
+                    "path": "linkId",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {"id": "q1", "topLinkId": "g1", "groupLinkId": "g1", "innerLinkId": "g1.1"},
+        {"id": "q1", "topLinkId": "g1", "groupLinkId": "g1", "innerLinkId": "g1.1.1"},
+        {"id": "q1", "topLinkId": "g1.1", "groupLinkId": "g1", "innerLinkId": "g1.1"},
+        {"id": "q1", "topLinkId": "g1.1", "groupLinkId": "g1", "innerLinkId": "g1.1.1"},
+        {"id": "q1", "topLinkId": "g1.1.1", "groupLinkId": "g1", "innerLinkId": "g1.1"},
+        {"id": "q1", "topLinkId": "g1.1.1", "groupLinkId": "g1", "innerLinkId": "g1.1.1"},
+        {"id": "q1", "topLinkId": "g2", "groupLinkId": "g1", "innerLinkId": "g1.1"},
+        {"id": "q1", "topLinkId": "g2", "groupLinkId": "g1", "innerLinkId": "g1.1.1"}
+      ]
+    },
+    {
+      "title": "forEach with repeat with forEach (triple nesting)",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "QuestionnaireResponse",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEach": "item",
+            "select": [
+              {
+                "column": [
+                  {
+                    "name": "outerLinkId",
+                    "path": "linkId",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "repeat": ["item"],
+                "select": [
+                  {
+                    "column": [
+                      {
+                        "name": "midLinkId",
+                        "path": "linkId",
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  {
+                    "forEach": "answer",
+                    "column": [
+                      {
+                        "name": "answerValue",
+                        "path": "value.ofType(string)",
+                        "type": "string"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "qr1",
+          "outerLinkId": "1",
+          "midLinkId": "1.1",
+          "answerValue": "Answer 1.1"
+        }
+      ]
+    },
+    {
+      "title": "repeat with forEach with repeat (triple nesting)",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "QuestionnaireResponse",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "repeat": ["item"],
+            "select": [
+              {
+                "column": [
+                  {
+                    "name": "outerLinkId",
+                    "path": "linkId",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "forEach": "answer",
+                "select": [
+                  {
+                    "column": [
+                      {
+                        "name": "midValue",
+                        "path": "value.ofType(string)",
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  {
+                    "repeat": ["item"],
+                    "column": [
+                      {
+                        "name": "innerLinkId",
+                        "path": "linkId",
+                        "type": "string"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "qr1",
+          "outerLinkId": "1.1",
+          "midValue": "Answer 1.1",
+          "innerLinkId": "1.1.1"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/spec.staged.test.js
+++ b/tests/spec.staged.test.js
@@ -1,7 +1,6 @@
 import fs from "fs";
 import path from "path";
 import {expect, test, describe, beforeAll, afterAll} from "bun:test"
-import {buildStagedQuery} from "../src/staged-sql-builder.js";
 import {validateVd} from "../src/view-parser.js";
 
 import {templateToQuery} from "../src/query-builder.js";
@@ -10,11 +9,6 @@ import fhirSchema from "../schemas/fhir-schema-r4.json";
 
 const verbose = process.env.VERBOSE === "1";
 const testDirectory = path.join(import.meta.dir, "./spec-tests/");
-
-// The staged emitter does not yet implement `repeat` (a later migration stage). Exclude that
-// suite; everything else — including `row_index` (`%rowIndex` for forEach/forEachOrNull/unionAll,
-// this stage) — is the official reference harness, unchanged.
-const EXCLUDE = /^(repeat)\./;
 
 let db;
 
@@ -26,7 +20,6 @@ let testFiles = [];
 
 files.forEach( f => {
 	if (/\.temp\.json|skip$|^\./.test(f)) return;
-	if (EXCLUDE.test(f)) return;
 	const testGroup = JSON.parse(fs.readFileSync(path.join(testDirectory, f)))
 	if (!testGroup.skip)
 		testFiles.push({fileName: f, testGroup});
@@ -42,15 +35,6 @@ const buildStaged = (view, resourceFile, rootKey="natural") => templateToQuery(
 	view, fhirSchema, stagedQueryTemplate,
 	[["test_file_path", resourceFile]], verbose, true, null, null, rootKey
 );
-
-describe("staged - unsupported directives", () => {
-	test("repeat is rejected with a clear error", () => {
-		const view = {resource: "QuestionnaireResponse", select: [
-			{forEach: "item", repeat: ["item"], column: [{name: "l", path: "linkId", type: "string"}]}
-		]};
-		expect(() => buildStagedQuery(view, fhirSchema, {})).toThrow(/repeat/);
-	});
-});
 
 describe("staged - column name validation", () => {
 	test("duplicate column names across sibling scopes are rejected", () => {

--- a/tests/staged-repeat.test.js
+++ b/tests/staged-repeat.test.js
@@ -1,0 +1,134 @@
+import path from "path";
+import {expect, test, describe, beforeAll, afterAll} from "bun:test";
+
+import {templateToQuery} from "../src/query-builder.js";
+import {stagedQueryTemplate, openMemoryDb, executeQuery} from "./test-util.js";
+import fhirSchema from "../schemas/fhir-schema-r4.json";
+
+// Locks in the typed-bridge behaviour (design D5, Risks/choice-type): a `forEach` *inside* a
+// `repeat` region whose columns use arbitrary FHIRPath (`value.ofType(<type>)`) must re-establish
+// typed evaluation off the from_json element — choice-type leaves (`value.ofType(string)` ->
+// `el.valueString`, `value.ofType(integer)` -> `el.valueInteger`) must bind against the from_json
+// structure. The official `repeat.json` suite never reads more than one choice type at once.
+
+const verbose = process.env.VERBOSE === "1";
+
+const resources = [
+	{
+		resourceType: "QuestionnaireResponse", id: "qr1",
+		item: [
+			{
+				linkId: "1",
+				item: [
+					{
+						linkId: "1.1",
+						answer: [
+							{valueString: "keep"},
+							{valueString: "drop"},
+							{valueInteger: 7}
+						]
+					}
+				]
+			}
+		]
+	}
+];
+
+const resourceFile = path.join(import.meta.dir, "./spec-tests/_staged-repeat.temp.json");
+
+// `forEach` over a `where`-filtered answer collection, the column a choice-type leaf — both
+// arbitrary FHIRPath evaluated typed against the from_json bridge inside the recursion.
+const view = {
+	resource: "QuestionnaireResponse",
+	select: [
+		{column: [{name: "id", path: "id", type: "id"}]},
+		{
+			repeat: ["item"],
+			select: [
+				{column: [{name: "linkId", path: "linkId", type: "string"}]},
+				{
+					forEach: "answer",
+					column: [
+						{name: "answerString", path: "value.ofType(string)", type: "string"},
+						{name: "answerInteger", path: "value.ofType(integer)", type: "integer"}
+					]
+				}
+			]
+		}
+	]
+};
+
+let db;
+beforeAll(async () => {
+	await Bun.write(resourceFile, JSON.stringify(resources));
+	db = await openMemoryDb();
+});
+afterAll(async () => { await db.close(); });
+
+describe("staged - repeat typed bridge (arbitrary FHIRPath)", () => {
+	["natural", "uuid"].forEach(rootKey => {
+		test(`choice-type ofType() forEach inside repeat [${rootKey}]`, async () => {
+			const sql = templateToQuery(
+				view, fhirSchema, stagedQueryTemplate,
+				[["test_file_path", resourceFile]], verbose, true, null, null, rootKey
+			);
+			if (verbose) console.log(sql);
+			const result = await executeQuery(db, sql);
+			// Each answer binds the matching choice type; the other is NULL.
+			expect(new Set(result)).toEqual(new Set([
+				{id: "qr1", linkId: "1.1", answerString: "keep", answerInteger: null},
+				{id: "qr1", linkId: "1.1", answerString: "drop", answerInteger: null},
+				{id: "qr1", linkId: "1.1", answerString: null, answerInteger: 7}
+			]));
+		});
+	});
+});
+
+// Regression for REPEAT_LAMBDA_COLLISION_BUG.md: a *column directly in a repeat scope* whose
+// path navigates through an array (e.g. `answer.value.ofType(string)`) compiles to a
+// `list_transform(el -> ...)`. The lambda parameter is hardcoded `el`, which collides with the
+// repeat bridge element (also aliased `el`) — DuckDB binds `el.valueString` to the bridge struct
+// (keys linkId/answer) instead of the lambda element, raising "Could not find key valuestring".
+describe("staged - repeat scope array-navigating column (lambda collision)", () => {
+	const collisionResources = [
+		{
+			resourceType: "QuestionnaireResponse", id: "qrc",
+			item: [
+				{linkId: "a", item: [{linkId: "a.1", answer: [{valueString: "x"}, {valueString: "y"}]}]}
+			]
+		}
+	];
+	const collisionFile = path.join(import.meta.dir, "./spec-tests/_staged-repeat-collision.temp.json");
+	const collisionView = {
+		resource: "QuestionnaireResponse",
+		select: [
+			{column: [{name: "id", path: "id", type: "id"}]},
+			{
+				repeat: ["item"],
+				column: [
+					{name: "linkId", path: "linkId", type: "string"},
+					{name: "answers", path: "answer.value.ofType(string)", collection: true, type: "string"}
+				]
+			}
+		]
+	};
+	const expected = [
+		{id: "qrc", linkId: "a", answers: []},
+		{id: "qrc", linkId: "a.1", answers: ["x", "y"]}
+	];
+
+	beforeAll(async () => { await Bun.write(collisionFile, JSON.stringify(collisionResources)); });
+
+	["natural", "uuid"].forEach(rootKey => {
+		test(`collection column navigating an array inside repeat [${rootKey}]`, async () => {
+			const sql = templateToQuery(
+				collisionView, fhirSchema, stagedQueryTemplate,
+				[["test_file_path", collisionFile]], verbose, true, null, null, rootKey
+			);
+			if (verbose) console.log(sql);
+			const result = await executeQuery(db, sql);
+			expect(new Set(result.map(r => JSON.stringify(r)))).toEqual(
+				new Set(expected.map(r => JSON.stringify(r))));
+		});
+	});
+});

--- a/tests/staged-repeat.test.js
+++ b/tests/staged-repeat.test.js
@@ -84,6 +84,87 @@ describe("staged - repeat typed bridge (arbitrary FHIRPath)", () => {
 	});
 });
 
+// Regression for the FORK-inside-a-repeat-body bug: a repeat body that itself forks (>=2 fan-out
+// children) over a resource with >1 descended node. The descent CTE keyed every node on `rid`
+// only (constant per resource), so the fork branches recombined via `JOIN USING(rid)` and
+// cross-produced across ALL nodes of the resource instead of per repeat node — wrong rows
+// (e.g. item "a" paired with item "b"'s answers). The repeat must carry a per-node identity into
+// the fork key. The official repeat.json suite misses this (its repeat+internal-fork cases all
+// expect a single row, which cannot expose the cross-product).
+describe("staged - fork inside a repeat body", () => {
+	const forkResources = [
+		{
+			resourceType: "QuestionnaireResponse", id: "qrf",
+			item: [
+				{linkId: "a", answer: [{valueString: "a1"}, {valueString: "a2"}]},
+				{linkId: "b", answer: [{valueString: "b1"}]}
+			]
+		}
+	];
+	const forkFile = path.join(import.meta.dir, "./_staged-repeat-fork.temp.json");
+	const forkView = {
+		resource: "QuestionnaireResponse",
+		select: [
+			{column: [{name: "id", path: "id", type: "id"}]},
+			{
+				repeat: ["item"],
+				select: [
+					{column: [{name: "linkId", path: "linkId", type: "string"}]},
+					{forEach: "answer", column: [{name: "v1", path: "value.ofType(string)", type: "string"}]},
+					{forEach: "answer", column: [{name: "v2", path: "value.ofType(string)", type: "string"}]}
+				]
+			}
+		]
+	};
+	// Per node, the two forEach:answer siblings cross-product: item "a" (2 answers) -> 2x2 = 4,
+	// item "b" (1 answer) -> 1x1 = 1, total 5 rows; v1/v2 always belong to the same item.
+	const expected = [
+		{id: "qrf", linkId: "a", v1: "a1", v2: "a1"},
+		{id: "qrf", linkId: "a", v1: "a1", v2: "a2"},
+		{id: "qrf", linkId: "a", v1: "a2", v2: "a1"},
+		{id: "qrf", linkId: "a", v1: "a2", v2: "a2"},
+		{id: "qrf", linkId: "b", v1: "b1", v2: "b1"}
+	];
+
+	beforeAll(async () => { await Bun.write(forkFile, JSON.stringify(forkResources)); });
+
+	["natural", "uuid"].forEach(rootKey => {
+		test(`two forEach siblings inside a repeat recombine per node [${rootKey}]`, async () => {
+			const sql = templateToQuery(
+				forkView, fhirSchema, stagedQueryTemplate,
+				[["test_file_path", forkFile]], verbose, true, null, null, rootKey
+			);
+			if (verbose) console.log(sql);
+			const result = await executeQuery(db, sql);
+			expect(new Set(result.map(r => JSON.stringify(r)))).toEqual(
+				new Set(expected.map(r => JSON.stringify(r))));
+		});
+	});
+});
+
+// `%rowIndex` indexing a repeat's OWN descent scope is Stage 4 (the recursive CTE has no
+// per-iteration ordinal). It must be rejected at build time, not silently bound to a constant 0.
+// `%rowIndex` for a forEach/forEachOrNull *inside* a repeat body is Stage 2 and keeps working
+// (covered by the choice-type fixtures' iteration); this only guards the own-scope case.
+describe("staged - %rowIndex over a repeat's own scope is rejected", () => {
+	const riView = {
+		resource: "QuestionnaireResponse",
+		select: [
+			{column: [{name: "id", path: "id", type: "id"}]},
+			{repeat: ["item"], column: [
+				{name: "linkId", path: "linkId", type: "string"},
+				{name: "ri", path: "%rowIndex", type: "integer"}
+			]}
+		]
+	};
+	test("throws rather than emitting a constant", () => {
+		expect(() => templateToQuery(
+			riView, fhirSchema, stagedQueryTemplate,
+			[["test_file_path", "/tmp/unused.json"]], verbose, true, null, null, "natural"
+		)).toThrow(/%rowIndex/);
+	});
+});
+
 // Regression for REPEAT_LAMBDA_COLLISION_BUG.md: a *column directly in a repeat scope* whose
 // path navigates through an array (e.g. `answer.value.ofType(string)`) compiles to a
 // `list_transform(el -> ...)`. The lambda parameter is hardcoded `el`, which collides with the

--- a/tests/test-util.js
+++ b/tests/test-util.js
@@ -4,7 +4,8 @@ import macros from "../templates/duck-macros";
 // Staged backend (SPEC_hybrid): the first CTE reuses the existing source mechanism;
 // the builder emits the rest of the query into {{fq_staged_tail}}.
 export const stagedQueryTemplate = `
-	WITH src AS {{fq_staged_src_materialized}}(
+	{{fq_staged_macros}}
+	{{fq_staged_with}} src AS {{fq_staged_src_materialized}}(
 		SELECT {{fq_staged_src}}
 		FROM read_json_auto(
 			'{{test_file_path}}'


### PR DESCRIPTION
Closes #29. Part of #1.

## Problem
The staged (hybrid) emitter rejected the SQL-on-FHIR `repeat` directive (`assertNoRepeat` threw). `repeat` is the one unbounded-depth directive and cannot live on the typed substrate.

## Solution
Lower `repeat` per SPEC_hybrid §5/§10:
- **Descent** runs in JSON: a `WITH RECURSIVE rep(node)` CTE whose seed is the typed navigation of the listed paths and whose recursive leg re-applies `fhir_list(rep.node -> '$.<path>')` over the listed paths only (excludes the seed, descends only the listed paths).
- **Typed bridge**: each visited JSON node is converted to a typed element via a pooled `from_json` cast macro (`fq_cast_<N>`, one per distinct structure), so every column / forEach / where inside the repeat body compiles via the existing typed leaf engine unchanged.
- **CHAIN vs FORK**: a lone `repeat` (single fan-out child of its scope) is a keyless CHAIN — scope scalars carry through the rCTE. A `repeat` beside ≥1 other fan-out is a FORK branch — it carries the fork key and recombines via `JOIN USING(rid[, ord…])`.
- The from_json bridge element is bound as `el_r` (not `el`) so a repeat-scope column navigating through an array (`answer.value.ofType(string)` → `list_transform(el -> …)`) does not shadow the bridge struct.

Supporting changes: `pathsToJsonStruct` + `forceJson` in the schema builder (a repeat seed reads as raw JSON[]); repeat-aware `viewPaths` + `applyForcedJson`; the `fhir_list` macro; `fq_staged_with` (leading `WITH RECURSIVE`) and `fq_staged_macros` (cast preamble) template placeholders.

DuckDB 1.4.1 only: recursive CTE under a leading `WITH RECURSIVE`; `lambda x:` form inside `list_transform`. No 1.5 / @duckdb/node-api.

## Verification
- `bun test`: **331 pass, 0 fail** (baseline on the base branch: 298 pass, 0 fail). The increase is the official `repeat.json` suite (16 cases × natural/uuid root keys) + `staged-repeat.test.js` (from_json bridge / choice-type / lambda-collision), minus the removed 'repeat is rejected' test.
- End-to-end CLI (`bun run ./src/cli.js`) on a QuestionnaireResponse:
  - **CHAIN** (root → `repeat item`): descends 1, 1.1, 1.2, 1.2.1, 2 — excludes the seed resource, descends only `item`. Emits a keyless `WITH RECURSIVE` chain.
  - **FORK** (`repeat item` beside `forEach item`): mints `id AS rid` in `src`, both branches carry `rid`, recombined `JOIN … USING (rid)` — 5 descendants × 2 top items = 10-row per-resource cross product.

## Scope note
`repeat` is complete here. `%rowIndex` indexing a repeat's **own** descent scope is **Stage 4** (the repeat.json suite contains no such case; the Stage-4-only `row_index_repeat.json` fixture was deliberately not copied). `%rowIndex` for forEach/forEachOrNull (Stage 2) keeps working, including inside a repeat body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)