### PR TITLE
Stage 4: %rowIndex over repeat (pre-order)

### DIFF
--- a/src/ddb-sql-builder.js
+++ b/src/ddb-sql-builder.js
@@ -70,13 +70,13 @@ export function astToSql(node, inLambda, inputType={}, rootVar="el", rowIndexSql
 			return {sql, outputType: {fhirType: node.type.fhirType, isArray: false}};
 
 		// `%rowIndex`: the 0-based position within the nearest enclosing iteration, threaded as
-		// `rowIndexSql` (bound to the iteration ordinal minus 1 by an enclosing forEach/forEachOrNull,
-		// else "0" at the resource root / a non-iterating branch). A `null` binding means the scope
-		// cannot supply a position — a `%rowIndex` indexing a `repeat`'s own descent scope (Stage 4,
-		// unsupported); reject it rather than silently emit a constant.
+		// `rowIndexSql` (bound to the iteration ordinal minus 1 by an enclosing forEach/forEachOrNull;
+		// to a pre-order descent window by an enclosing `repeat`; else "0" at the resource root / a
+		// non-iterating branch). A `null` binding means the scope cannot supply a position — guard
+		// against silently emitting a constant if a scope ever reaches the leaf engine without one.
 		case 'rowIndex':
 			if (rowIndexSql == null)
-				throw new Error("%rowIndex referencing a repeat's own descent scope is not supported");
+				throw new Error("%rowIndex referencing a scope with no defined iteration position");
 			return {sql: rowIndexSql, outputType: {fhirType: "integer", isArray: false}};
 
 		//and, or, add, subtract, multiply

--- a/src/staged-sql-builder.js
+++ b/src/staged-sql-builder.js
@@ -65,6 +65,54 @@ function subtreeHasFork(node) {
 	return result;
 }
 
+// Raw-string `%rowIndex` detection, used ONLY for the structural look-ahead that forces a partition
+// key down a spine to a `%rowIndex` repeat (Stage 4). Over-approximation is safe here: a false
+// positive can only force an extra, harmless carried key, never alter a `%rowIndex`-free view (which
+// contains no `%rowIndex` token to match). The precise per-scope binding decision still parses the
+// resolved AST when the column is compiled, so this raw scan never affects which value is emitted.
+function pathMentionsRowIndex(p) {
+	return typeof p === "string" && /%rowIndex\b/.test(p);
+}
+function unionBranchesMentionRowIndex(branches) {
+	return branches.some(b => {
+		if (b.unionAll) return unionBranchesMentionRowIndex(b.unionAll);
+		if (b.forEach || b.forEachOrNull || b.repeat) return false; // opens its own scope
+		return (b.column || []).some(c => pathMentionsRowIndex(c.path || c.name));
+	});
+}
+// Does a `repeat`'s own scope (direct + transparently-merged columns, and columns-only `unionAll`
+// branches) reference `%rowIndex`? Mirrors the candidate set the scope actually compiles its
+// `%rowIndex`-binding columns against (a nested forEach/repeat/union-iterating branch opens its own
+// scope and is excluded).
+function repeatScopeUsesRowIndex(repeatNode) {
+	const {columns, fanouts} = collectScope(repeatNode);
+	if (columns.some(c => pathMentionsRowIndex(c.path || c.name))) return true;
+	return fanouts.filter(f => f.type === "union")
+		.some(f => unionBranchesMentionRowIndex(f.node.unionAll));
+}
+// Does any `repeat` anywhere in `node`'s subtree have a body that references `%rowIndex`? A
+// `%rowIndex` repeat assigns its index by a window partitioned by its enclosing-scope instance, so
+// the resource key (`rid`) and any enclosing iterating step's ordinal must be minted on the spine
+// down to that repeat. Forces the root key and carried ordinals even in a fork-free view.
+function subtreeHasRepeatUsingRowIndex(node) {
+	if (!node || typeof node !== "object") return false;
+	if (node.repeat && repeatScopeUsesRowIndex(node)) return true;
+	return (node.select || []).some(subtreeHasRepeatUsingRowIndex)
+		|| (node.unionAll || []).some(subtreeHasRepeatUsingRowIndex);
+}
+
+// Deep-walk a FHIRPath AST (nested arrays of segments, each with possible `args`/`type` sub-trees)
+// for the contextual `%rowIndex` segment emitted by the front end. Used to decide precisely, before
+// a repeat's columns are compiled, whether its scope binds `%rowIndex`. The AST is a finite tree.
+function astHasRowIndex(node) {
+	if (Array.isArray(node)) return node.some(astHasRowIndex);
+	if (node && typeof node === "object") {
+		if (node.segmentType === "rowIndex") return true;
+		return Object.values(node).some(astHasRowIndex);
+	}
+	return false;
+}
+
 // VD column names in document (tree) order — the output projection contract.
 function columnOrder(node) {
 	let names = [];
@@ -141,7 +189,12 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 
 	const viewHasRepeat = hasRepeat(vd);
 	const viewHasFork = subtreeHasFork(vd);
-	const rootKey = viewHasFork ? ["rid"] : [];
+	// A `%rowIndex` repeat partitions its pre-order window by its enclosing-scope instance, so it
+	// needs a per-resource partition key even when the view has no fork — force the root `rid`
+	// whenever any repeat below uses `%rowIndex` (Stage 4), in addition to the fork case.
+	const viewHasRepeatRowIndex = subtreeHasRepeatUsingRowIndex(vd);
+	const forceRootKey = viewHasFork || viewHasRepeatRowIndex;
+	const rootKey = forceRootKey ? ["rid"] : [];
 
 	// Cast macros: each distinct `from_json` structure becomes one `fq_cast_*` macro emitted in
 	// the preamble; identical structures (e.g. a repeat's single canonical descent type) share a
@@ -173,20 +226,42 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 	// Natural-key mode reads the resource key, which the ViewDefinition need not otherwise
 	// reference; expose its AST so the caller can add it to the typed read schema. Lazy: only
 	// when a fork actually needs the key (chain-only views and "uuid" mode add nothing).
-	const resourceKeyAst = (viewHasFork && rootKeyMode === "natural")
+	const resourceKeyAst = (forceRootKey && rootKeyMode === "natural")
 		? fhirpathToAst("getResourceKey()", vd.resource, schema, vars)
 		: null;
 	// "uuid()" is volatile: the source scope must be materialised so it is evaluated exactly
-	// once per resource and all branches join on the same key.
-	const srcMaterialized = viewHasFork && rootKeyMode === "uuid";
+	// once per resource and all branches (and a repeat's recursive descent) join on the same key.
+	const srcMaterialized = forceRootKey && rootKeyMode === "uuid";
 
 	// The typed element produced by a from_json bridge over a JSON node column (bound as BRIDGE_VAR).
-	// `rowIndexSql: null` — a repeat's own descent scope has no positional ordinal (the recursive CTE
-	// has no per-iteration index; `%rowIndex` over a repeat's own scope is Stage 4), so a `%rowIndex`
-	// leaf compiled directly against this element is rejected rather than silently bound to a constant.
-	// A forEach/forEachOrNull *inside* a repeat body rebinds `rowIndexSql` to its real ordinal.
+	// `rowIndexSql: null` by default — a repeat's own descent scope has no positional ordinal unless
+	// its body actually references `%rowIndex` (Stage 4), in which case `emitRepeat` rebinds it to the
+	// pre-order window column. Left null, a stray `%rowIndex` leaf is rejected rather than silently
+	// bound to a constant. A forEach/forEachOrNull *inside* a repeat body rebinds it to its ordinal.
 	function bridgeElem(seed) {
 		return {ref: BRIDGE_VAR, inLambda: true, seed, inputType: {fhirType: "BackboneElement", isArray: false, schemaPath: seed}, rowIndexSql: null};
+	}
+
+	// Does `pathExpr`, evaluated against `elem`, reference `%rowIndex`? Parse it (cheap at build
+	// time) and look for the contextual segment, rather than pattern-matching the raw string.
+	const pathUsesRowIndex = (pathExpr, elem) =>
+		astHasRowIndex(fhirpathToAst(pathExpr, elem.seed, schema, vars));
+	// Does any column bound against THIS scope's element reference `%rowIndex`? Candidates are the
+	// scope's own (direct + transparently merged) columns and any columns-only `unionAll` branch
+	// (which materialises into this stage). A nested forEach/repeat/iterating-union branch opens its
+	// own scope and is excluded — it is handled when ITS parent makes the same decision.
+	function scopeUsesRowIndex(node, elem) {
+		const {columns, fanouts} = collectScope(node);
+		if (columns.some(c => pathUsesRowIndex(c.path || c.name, elem))) return true;
+		return fanouts.filter(f => f.type === "union")
+			.some(f => unionColsOnlyUseRowIndex(f.node.unionAll, elem));
+	}
+	function unionColsOnlyUseRowIndex(branches, elem) {
+		return branches.some(b => {
+			if (b.unionAll) return unionColsOnlyUseRowIndex(b.unionAll, elem);
+			if (b.forEach || b.forEachOrNull || b.repeat) return false; // opens its own scope
+			return (b.column || []).some(c => pathUsesRowIndex(c.path || c.name, elem));
+		});
 	}
 
 	// Prepare a repeat fan-out: validate its paths, resolve the descent element type, and
@@ -197,6 +272,9 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 		f.childElem = B.childElemOf(f.listedPaths[0], elem);
 		f.seedCol = name("a") + "_seed";
 		stageSelect.push(`${typedSeed(f.listedPaths, elem, B)} AS ${f.seedCol}`);
+		// Does the repeat body bind `%rowIndex`? Parse against the typed bridge element it will be
+		// evaluated under — drives the pre-order path + window in `emitRepeat` (Stage 4).
+		f.usesRowIndex = scopeUsesRowIndex(f.node, bridgeElem(f.childElem.seed));
 		// A seed field read in a typed scope must be JSON[] even if a sibling forEach types it.
 		if (schemaPrefix) f.listedPaths.forEach(p =>
 			forcedJsonPaths.push([...schemaPrefix, ...p.split(".")].join(".")));
@@ -211,22 +289,29 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 		const carryProj = (rel) => carryCols.map(c => `${rel}.${c}`);
 		const lead = (cols) => cols.length ? cols.join(", ") + ", " : "";
 
-		// A repeat body that forks (>=2 fan-out children below) needs a per-node identity: the rCTE
-		// otherwise keys every descended node on the carried key columns only (constant per resource
-		// for a CHAIN repeat, the parent fork key for a FORK branch), so the body's fork branches would
-		// recombine via `JOIN USING(keyCols)` and cross-product across ALL nodes of the resource. When
-		// so, carry an integer descent `path` (the per-level `WITH ORDINALITY` ordinals from the seed to
-		// a node) through both legs, then assign a deterministic pre-order index at the bridge
-		// (`ORDER BY path`: `[1] < [1,1] < [1,2] < [2]`). The index is unique per visited node and
-		// survives the fork joins as an extra key column. (This is the same descent key Stage 4 binds
-		// for `%rowIndex` over a repeat's own scope; here it is purely a fork-recombination key.)
+		// A repeat assigns a deterministic pre-order index over its descent by carrying an integer
+		// descent `path` (the per-level `WITH ORDINALITY` ordinals from the seed to a node) through
+		// both legs, then ranking with `row_number() OVER (PARTITION BY {enclosing-scope key} ORDER BY
+		// path)`. Ordering the `BIGINT[]` path element-wise gives depth-first pre-order
+		// (`[1] < [1,1] < [1,2] < [2]`); the index is unique per visited node and assigned at the
+		// repeat's OWN scope (one row per node), before any fork recombination. That single window
+		// serves up to three roles, so it is computed whenever ANY of them is needed:
+		//   - needNodeKey: a forking repeat body needs a per-node identity carried as an extra key, or
+		//     its fork branches would `JOIN USING(keyCols)` and cross-product across ALL nodes;
+		//   - usesRowIndex: the body binds `%rowIndex` to this index (Stage 4), materialised as a
+		//     scalar that survives any later fork join;
+		//   - innerNeedsOuterRn: a nested `%rowIndex` repeat needs THIS repeat's index as its window
+		//     partition surrogate (so repeat-in-repeat chains via `(rid, outer_rn)`, never a LIST).
 		const needNodeKey = subtreeHasFork(f.node);
+		const innerNeedsOuterRn = (f.node.select || []).some(subtreeHasRepeatUsingRowIndex)
+			|| (f.node.unionAll || []).some(subtreeHasRepeatUsingRowIndex);
+		const needRn = needNodeKey || f.usesRowIndex || innerNeedsOuterRn;
 
 		const repName = name("rep");
-		const seedPath = needNodeKey ? `[ord]::BIGINT[] AS path, ` : "";
-		const recPath = needNodeKey ? `list_append(${repName}.path, ord), ` : "";
-		const seedOrd = needNodeKey ? ` WITH ORDINALITY AS _s(node, ord)` : ` AS _s(node)`;
-		const recOrd = needNodeKey ? ` WITH ORDINALITY AS _r(node, ord)` : ` AS _r(node)`;
+		const seedPath = needRn ? `[ord]::BIGINT[] AS path, ` : "";
+		const recPath = needRn ? `list_append(${repName}.path, ord), ` : "";
+		const seedOrd = needRn ? ` WITH ORDINALITY AS _s(node, ord)` : ` AS _s(node)`;
+		const recOrd = needRn ? ` WITH ORDINALITY AS _r(node, ord)` : ` AS _r(node)`;
 		const seedLeg = `SELECT ${lead(carryProj(parentRel))}${seedPath}_s.node AS node\n    FROM ${parentRel}, UNNEST(${parentRel}.${f.seedCol})${seedOrd}`;
 		const recLeg = `SELECT ${lead(carryProj(repName))}${recPath}_r.node\n    FROM ${repName}, UNNEST(${jsonFold(f.listedPaths, `${repName}.node`)})${recOrd}`;
 		ctes.push(`${repName} AS (\n    ${seedLeg}\n    UNION ALL\n    ${recLeg}\n  )`);
@@ -236,23 +321,29 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 		const structure = B.repeatStructure(f.node, f.childElem.seed);
 		const cast = `${castMacroFor(structure, f.childElem.seed)}(node)`;
 		const bridge = name("repb");
+		const bodyElem = bridgeElem(f.childElem.seed);
 		let bodyKeyCols = keyCols;
-		if (needNodeKey) {
+		if (needRn) {
 			// `ORDER BY path` is a total, deterministic order within the partition (paths are unique per
 			// node), so the index is reproducible across every reference to the bridge — no MATERIALIZED
-			// needed. `keyCols` always includes the resource key here (a body fork forces a root fork key).
-			const nodeKey = `nord${keyCols.length}`;
+			// needed. When a fork or a nested `%rowIndex` repeat needs the index as a key, `keyCols`
+			// always includes the resource key (both force the root key), so the partition is per-resource.
+			const rnCol = `nord${keyCols.length}`;
 			const part = keyCols.length ? `PARTITION BY ${keyCols.join(", ")} ` : "";
-			const rn = `(row_number() OVER (${part}ORDER BY path) - 1)::INTEGER AS ${nodeKey}`;
+			const rn = `(row_number() OVER (${part}ORDER BY path) - 1)::INTEGER AS ${rnCol}`;
 			ctes.push(`${bridge} AS (\n  SELECT ${lead(carryCols)}${rn}, ${cast} AS ${BRIDGE_VAR}\n  FROM ${repName}\n)`);
-			bodyKeyCols = [...keyCols, nodeKey];
+			if (f.usesRowIndex) bodyElem.rowIndexSql = rnCol;             // this repeat's own %rowIndex
+			// Carry the index as a key when a fork below recombines on it, or a nested `%rowIndex`
+			// repeat partitions by it. (A pure-`%rowIndex` repeat with no fork/nested-repeat below
+			// reads the index in its immediate body and need not carry it as a key.)
+			if (needNodeKey || innerNeedsOuterRn) bodyKeyCols = [...keyCols, rnCol];
 		} else {
 			ctes.push(`${bridge} AS (\n  SELECT ${lead(carryCols)}${cast} AS ${BRIDGE_VAR}\n  FROM ${repName}\n)`);
 		}
 
-		// The body of a repeat is evaluated typed (its element is the from_json `el`); nested
-		// repeat seeds arrive as `el.<field>` JSON[] and re-enter `WITH RECURSIVE`.
-		return emitScope(f.node, bridgeElem(f.childElem.seed), carried, bodyKeyCols, bridge, false, null);
+		// The body of a repeat is evaluated typed (its element is the from_json bridge); nested
+		// repeat seeds arrive as `<bridge>.<field>` JSON[] and re-enter `WITH RECURSIVE`.
+		return emitScope(f.node, bodyElem, carried, bodyKeyCols, bridge, false, null);
 	}
 
 	// A `forEach` over a field that a sibling `repeat` forces to JSON[] (the shared-field case):
@@ -311,7 +402,12 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 			f.arrCol = name("a") + "_arr";
 			f.orNull = !!f.node.forEachOrNull;
 			f.childElem = childElem;
-			f.needsOrd = subtreeHasFork(f.node);
+			// Carry this iteration's ordinal forward as a recombination KEY when a fork below needs it,
+			// or a `%rowIndex` repeat below needs it as a per-instance window partition surrogate (so a
+			// repeat nested under a forEach restarts its pre-order index per enclosing element). Either
+			// way the child key gains `ord{N}`; otherwise the ordinal is private (just this scope's
+			// `%rowIndex`). The enclosing forEach's own `%rowIndex` binding is unchanged.
+			f.needsOrd = subtreeHasFork(f.node) || subtreeHasRepeatUsingRowIndex(f.node);
 			stageSelect.push(`${arrSql} AS ${f.arrCol}`);
 		});
 		// materialise each repeat's seed array (the JSON descent reads from it)

--- a/src/staged-sql-builder.js
+++ b/src/staged-sql-builder.js
@@ -65,40 +65,52 @@ function subtreeHasFork(node) {
 	return result;
 }
 
+// Does a scope reference `%rowIndex` in a column it binds itself? The candidate set is the scope's
+// own (direct + transparently-merged) columns and any columns-only `unionAll` branch (which
+// materialises into this stage); a nested forEach/repeat or an iterating union branch opens its own
+// scope and is excluded. `colHit(col)` decides whether a single column mentions `%rowIndex` — there
+// are two detectors (see below) sharing this one traversal so the "opens its own scope" rule lives
+// in a single place.
+function scopeMentionsRowIndex(node, colHit) {
+	const {columns, fanouts} = collectScope(node);
+	if (columns.some(colHit)) return true;
+	return fanouts.filter(f => f.type === "union")
+		.some(f => unionColsMentionRowIndex(f.node.unionAll, colHit));
+}
+function unionColsMentionRowIndex(branches, colHit) {
+	return branches.some(b => {
+		if (b.unionAll) return unionColsMentionRowIndex(b.unionAll, colHit);
+		if (b.forEach || b.forEachOrNull || b.repeat) return false; // opens its own scope
+		return (b.column || []).some(colHit);
+	});
+}
+
 // Raw-string `%rowIndex` detection, used ONLY for the structural look-ahead that forces a partition
 // key down a spine to a `%rowIndex` repeat (Stage 4). Over-approximation is safe here: a false
 // positive can only force an extra, harmless carried key, never alter a `%rowIndex`-free view (which
 // contains no `%rowIndex` token to match). The precise per-scope binding decision still parses the
-// resolved AST when the column is compiled, so this raw scan never affects which value is emitted.
+// resolved AST when the column is compiled (see `scopeUsesRowIndex`), so this raw scan never affects
+// which value is emitted.
 function pathMentionsRowIndex(p) {
 	return typeof p === "string" && /%rowIndex\b/.test(p);
 }
-function unionBranchesMentionRowIndex(branches) {
-	return branches.some(b => {
-		if (b.unionAll) return unionBranchesMentionRowIndex(b.unionAll);
-		if (b.forEach || b.forEachOrNull || b.repeat) return false; // opens its own scope
-		return (b.column || []).some(c => pathMentionsRowIndex(c.path || c.name));
-	});
-}
-// Does a `repeat`'s own scope (direct + transparently-merged columns, and columns-only `unionAll`
-// branches) reference `%rowIndex`? Mirrors the candidate set the scope actually compiles its
-// `%rowIndex`-binding columns against (a nested forEach/repeat/union-iterating branch opens its own
-// scope and is excluded).
-function repeatScopeUsesRowIndex(repeatNode) {
-	const {columns, fanouts} = collectScope(repeatNode);
-	if (columns.some(c => pathMentionsRowIndex(c.path || c.name))) return true;
-	return fanouts.filter(f => f.type === "union")
-		.some(f => unionBranchesMentionRowIndex(f.node.unionAll));
-}
+const colMentionsRowIndex = c => pathMentionsRowIndex(c.path || c.name);
+const repeatScopeUsesRowIndex = repeatNode => scopeMentionsRowIndex(repeatNode, colMentionsRowIndex);
+
 // Does any `repeat` anywhere in `node`'s subtree have a body that references `%rowIndex`? A
 // `%rowIndex` repeat assigns its index by a window partitioned by its enclosing-scope instance, so
 // the resource key (`rid`) and any enclosing iterating step's ordinal must be minted on the spine
-// down to that repeat. Forces the root key and carried ordinals even in a fork-free view.
+// down to that repeat. Forces the root key and carried ordinals even in a fork-free view. Memoised
+// like `subtreeHasFork` — emitScope queries it per fan-out as it descends overlapping subtrees.
+const repeatRowIndexCache = new WeakMap();
 function subtreeHasRepeatUsingRowIndex(node) {
 	if (!node || typeof node !== "object") return false;
-	if (node.repeat && repeatScopeUsesRowIndex(node)) return true;
-	return (node.select || []).some(subtreeHasRepeatUsingRowIndex)
+	if (repeatRowIndexCache.has(node)) return repeatRowIndexCache.get(node);
+	const result = (node.repeat && repeatScopeUsesRowIndex(node))
+		|| (node.select || []).some(subtreeHasRepeatUsingRowIndex)
 		|| (node.unionAll || []).some(subtreeHasRepeatUsingRowIndex);
+	repeatRowIndexCache.set(node, result);
+	return result;
 }
 
 // Deep-walk a FHIRPath AST (nested arrays of segments, each with possible `args`/`type` sub-trees)
@@ -242,27 +254,12 @@ export function buildStagedQuery(vd, schema, vars, opts = {}) {
 		return {ref: BRIDGE_VAR, inLambda: true, seed, inputType: {fhirType: "BackboneElement", isArray: false, schemaPath: seed}, rowIndexSql: null};
 	}
 
-	// Does `pathExpr`, evaluated against `elem`, reference `%rowIndex`? Parse it (cheap at build
-	// time) and look for the contextual segment, rather than pattern-matching the raw string.
-	const pathUsesRowIndex = (pathExpr, elem) =>
-		astHasRowIndex(fhirpathToAst(pathExpr, elem.seed, schema, vars));
-	// Does any column bound against THIS scope's element reference `%rowIndex`? Candidates are the
-	// scope's own (direct + transparently merged) columns and any columns-only `unionAll` branch
-	// (which materialises into this stage). A nested forEach/repeat/iterating-union branch opens its
-	// own scope and is excluded — it is handled when ITS parent makes the same decision.
-	function scopeUsesRowIndex(node, elem) {
-		const {columns, fanouts} = collectScope(node);
-		if (columns.some(c => pathUsesRowIndex(c.path || c.name, elem))) return true;
-		return fanouts.filter(f => f.type === "union")
-			.some(f => unionColsOnlyUseRowIndex(f.node.unionAll, elem));
-	}
-	function unionColsOnlyUseRowIndex(branches, elem) {
-		return branches.some(b => {
-			if (b.unionAll) return unionColsOnlyUseRowIndex(b.unionAll, elem);
-			if (b.forEach || b.forEachOrNull || b.repeat) return false; // opens its own scope
-			return (b.column || []).some(c => pathUsesRowIndex(c.path || c.name, elem));
-		});
-	}
+	// Does a scope bound against `elem` reference `%rowIndex`? The precise binding decision: parse
+	// each candidate column (cheap at build time) and look for the contextual segment, rather than
+	// pattern-matching the raw string. Reuses the shared `scopeMentionsRowIndex` traversal (same
+	// "opens its own scope" rule as the raw look-ahead) with an AST-based per-column predicate.
+	const scopeUsesRowIndex = (node, elem) =>
+		scopeMentionsRowIndex(node, c => astHasRowIndex(fhirpathToAst(c.path || c.name, elem.seed, schema, vars)));
 
 	// Prepare a repeat fan-out: validate its paths, resolve the descent element type, and
 	// materialise the seed array into the owning stage's projection.

--- a/tests/row-index-repeat.test.js
+++ b/tests/row-index-repeat.test.js
@@ -1,0 +1,46 @@
+import fs from "fs";
+import path from "path";
+import {expect, test, describe, beforeAll, afterAll} from "bun:test";
+
+import {templateToQuery} from "../src/query-builder.js";
+import {stagedQueryTemplate, openMemoryDb, executeQuery} from "./test-util.js";
+import fhirSchema from "../schemas/fhir-schema-r4.json";
+
+// Extended %rowIndex-over-repeat runner (Stage 4). The fixture `row_index_repeat.json` is marked
+// `skip:true` so the generic auto-discovery spec suite ignores it (these cases go beyond the
+// official SQL-on-FHIR tests); this dedicated runner reads the fixture directly and exercises the
+// staged (hybrid) emitter — the sole emitter — in both root-key modes. Results are compared as Sets
+// (order-independent), so each case is verified by the index value bound to each discriminator, not
+// by output row order.
+
+const verbose = process.env.VERBOSE === "1";
+
+const fixturePath = path.join(import.meta.dir, "./spec-tests/row_index_repeat.json");
+const fixture = JSON.parse(fs.readFileSync(fixturePath));
+const resourceFile = path.join(import.meta.dir, "./spec-tests/_row_index_repeat.temp.json");
+
+const buildStaged = (view, rootKey) => templateToQuery(
+	view, fhirSchema, stagedQueryTemplate,
+	[["test_file_path", resourceFile]], verbose, true, null, null, rootKey
+);
+
+let db;
+beforeAll(async () => {
+	await Bun.write(resourceFile, JSON.stringify(fixture.resources));
+	db = await openMemoryDb();
+});
+afterAll(async () => { await db.close(); });
+
+describe("staged - " + fixture.title, () => {
+	fixture.tests.forEach(testCase => {
+		["natural", "uuid"].forEach(rootKey => {
+			test(`${testCase.title} [${rootKey}]`, async () => {
+				const sql = buildStaged(testCase.view, rootKey);
+				if (verbose) console.log(sql);
+				const result = await executeQuery(db, sql);
+				expect(new Set(result.map(r => JSON.stringify(r))))
+					.toEqual(new Set(testCase.expect.map(r => JSON.stringify(r))));
+			});
+		});
+	});
+});

--- a/tests/spec-tests/row_index_repeat.json
+++ b/tests/spec-tests/row_index_repeat.json
@@ -1,0 +1,230 @@
+{
+  "title": "row_index_repeat",
+  "description": "Extended %rowIndex-over-repeat cases NOT covered by the official row_index.json (which has a single root-level repeat over one resource). Staged backend only: depth-first pre-order numbering for repeat, per-enclosing-instance partitioning, repeat-under-forEach, repeat-in-repeat, repeat-in-unionAll, and repeat-at-a-fork. Marked skip:true so the generic auto-discovery suites (spec.test.js / spec.staged.test.js) do not run it; a dedicated staged-only runner (see change add-rowindex-repeat-preorder) loads it directly and exercises only the staged template. Each test's discriminator column makes rows attributable under the order-independent Set comparison, so pre-order is verified by the index value bound to each linkId, not by output row order.",
+  "skip": true,
+  "fhirVersion": ["5.0.0", "4.0.1", "3.0.2"],
+  "resources": [
+    {
+      "resourceType": "QuestionnaireResponse",
+      "id": "qr1",
+      "status": "completed",
+      "item": [
+        {
+          "linkId": "1",
+          "item": [
+            { "linkId": "1.1" },
+            { "linkId": "1.2" }
+          ]
+        },
+        {
+          "linkId": "2",
+          "item": [
+            { "linkId": "2.1" }
+          ]
+        }
+      ]
+    },
+    {
+      "resourceType": "QuestionnaireResponse",
+      "id": "qr2",
+      "status": "completed",
+      "item": [
+        {
+          "linkId": "A",
+          "item": [
+            { "linkId": "A.1" }
+          ]
+        },
+        {
+          "linkId": "B"
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "title": "%rowIndex over a fork-free repeat partitions per resource",
+      "description": "A lone repeat (single fan-out child => CHAIN, no fork) over MULTIPLE resources. row_index.json cannot catch a missing PARTITION BY because it has only one QuestionnaireResponse; with two, the pre-order index must restart at 0 per resource, which requires the emitter to force a per-resource partition key (rid) even though no fork exists.",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "QuestionnaireResponse",
+        "status": "active",
+        "select": [
+          { "column": [ { "name": "id", "path": "id", "type": "id" } ] },
+          {
+            "repeat": ["item"],
+            "column": [
+              { "name": "item_index", "path": "%rowIndex", "type": "integer" },
+              { "name": "linkId", "path": "linkId", "type": "string" }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        { "id": "qr1", "item_index": 0, "linkId": "1" },
+        { "id": "qr1", "item_index": 1, "linkId": "1.1" },
+        { "id": "qr1", "item_index": 2, "linkId": "1.2" },
+        { "id": "qr1", "item_index": 3, "linkId": "2" },
+        { "id": "qr1", "item_index": 4, "linkId": "2.1" },
+        { "id": "qr2", "item_index": 0, "linkId": "A" },
+        { "id": "qr2", "item_index": 1, "linkId": "A.1" },
+        { "id": "qr2", "item_index": 2, "linkId": "B" }
+      ]
+    },
+    {
+      "title": "%rowIndex over a repeat nested inside a forEach restarts per enclosing element",
+      "description": "forEach item (top-level groups) with a repeat over the group's sub-items. The repeat's pre-order index must restart per (resource, group), so the enclosing forEach must mint an ordinal key carried down to the repeat even though the whole view is fork-free. Group B (qr2) has no sub-items: its repeat is empty (INNER) and yields no rows.",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "QuestionnaireResponse",
+        "status": "active",
+        "select": [
+          { "column": [ { "name": "id", "path": "id", "type": "id" } ] },
+          {
+            "forEach": "item",
+            "column": [
+              { "name": "group_index", "path": "%rowIndex", "type": "integer" },
+              { "name": "group_link", "path": "linkId", "type": "string" }
+            ],
+            "select": [
+              {
+                "repeat": ["item"],
+                "column": [
+                  { "name": "item_index", "path": "%rowIndex", "type": "integer" },
+                  { "name": "linkId", "path": "linkId", "type": "string" }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        { "id": "qr1", "group_index": 0, "group_link": "1", "item_index": 0, "linkId": "1.1" },
+        { "id": "qr1", "group_index": 0, "group_link": "1", "item_index": 1, "linkId": "1.2" },
+        { "id": "qr1", "group_index": 1, "group_link": "2", "item_index": 0, "linkId": "2.1" },
+        { "id": "qr2", "group_index": 0, "group_link": "A", "item_index": 0, "linkId": "A.1" }
+      ]
+    },
+    {
+      "title": "%rowIndex over a repeat nested inside a repeat chains its index",
+      "description": "Outer repeat over all items (pre-order); for each visited outer node, an inner repeat over that node's sub-items. The inner index must restart per outer node, which requires partitioning the inner window by the outer repeat's own %rowIndex (the (rid, outer_rn) chaining) rather than by a list. Outer nodes with no sub-items yield no rows (inner repeat is empty/INNER). NOTE: this case is not exercised by the official suite.",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "QuestionnaireResponse",
+        "status": "active",
+        "select": [
+          { "column": [ { "name": "id", "path": "id", "type": "id" } ] },
+          {
+            "repeat": ["item"],
+            "column": [
+              { "name": "outer_index", "path": "%rowIndex", "type": "integer" },
+              { "name": "outer_link", "path": "linkId", "type": "string" }
+            ],
+            "select": [
+              {
+                "repeat": ["item"],
+                "column": [
+                  { "name": "inner_index", "path": "%rowIndex", "type": "integer" },
+                  { "name": "inner_link", "path": "linkId", "type": "string" }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        { "id": "qr1", "outer_index": 0, "outer_link": "1", "inner_index": 0, "inner_link": "1.1" },
+        { "id": "qr1", "outer_index": 0, "outer_link": "1", "inner_index": 1, "inner_link": "1.2" },
+        { "id": "qr1", "outer_index": 3, "outer_link": "2", "inner_index": 0, "inner_link": "2.1" },
+        { "id": "qr2", "outer_index": 0, "outer_link": "A", "inner_index": 0, "inner_link": "A.1" }
+      ]
+    },
+    {
+      "title": "%rowIndex over a repeat inside a unionAll branch numbers independently",
+      "description": "A unionAll whose first branch is a repeat (pre-order over all items, numbering its own visited nodes) and whose second branch is a non-iterating columns-only branch (which inherits the enclosing index => 0 at the root). The repeat branch must be detected through the union and given a forced per-resource partition; the columns-only sibling is independent. (A sibling forEach over the same `item` field would additionally exercise the orthogonal repeat-forces-JSON shared-field handling for union branches, which is out of scope here.)",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "QuestionnaireResponse",
+        "status": "active",
+        "select": [
+          { "column": [ { "name": "id", "path": "id", "type": "id" } ] },
+          {
+            "unionAll": [
+              {
+                "repeat": ["item"],
+                "column": [
+                  { "name": "idx", "path": "%rowIndex", "type": "integer" },
+                  { "name": "val", "path": "linkId", "type": "string" },
+                  { "name": "marker", "path": "'rep'", "type": "string" }
+                ]
+              },
+              {
+                "column": [
+                  { "name": "idx", "path": "%rowIndex", "type": "integer" },
+                  { "name": "val", "path": "status", "type": "string" },
+                  { "name": "marker", "path": "'root'", "type": "string" }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        { "id": "qr1", "idx": 0, "val": "1", "marker": "rep" },
+        { "id": "qr1", "idx": 1, "val": "1.1", "marker": "rep" },
+        { "id": "qr1", "idx": 2, "val": "1.2", "marker": "rep" },
+        { "id": "qr1", "idx": 3, "val": "2", "marker": "rep" },
+        { "id": "qr1", "idx": 4, "val": "2.1", "marker": "rep" },
+        { "id": "qr1", "idx": 0, "val": "completed", "marker": "root" },
+        { "id": "qr2", "idx": 0, "val": "A", "marker": "rep" },
+        { "id": "qr2", "idx": 1, "val": "A.1", "marker": "rep" },
+        { "id": "qr2", "idx": 2, "val": "B", "marker": "rep" },
+        { "id": "qr2", "idx": 0, "val": "completed", "marker": "root" }
+      ]
+    },
+    {
+      "title": "%rowIndex over a repeat at a fork survives recombination",
+      "description": "A root fork: a repeat sibling and a forEach sibling (two fan-out children => FORK, key = rid). The repeat's pre-order %rowIndex must be assigned at the repeat's own scope and carried as a scalar through the fork JOIN, NOT recomputed on the cross-product output. The result is the per-resource cross product of the repeat rows and the forEach rows, each retaining its own index.",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "QuestionnaireResponse",
+        "status": "active",
+        "select": [
+          { "column": [ { "name": "id", "path": "id", "type": "id" } ] },
+          {
+            "repeat": ["item"],
+            "column": [
+              { "name": "r_idx", "path": "%rowIndex", "type": "integer" },
+              { "name": "r_link", "path": "linkId", "type": "string" }
+            ]
+          },
+          {
+            "forEach": "item",
+            "column": [
+              { "name": "f_idx", "path": "%rowIndex", "type": "integer" },
+              { "name": "f_link", "path": "linkId", "type": "string" }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        { "id": "qr1", "r_idx": 0, "r_link": "1",   "f_idx": 0, "f_link": "1" },
+        { "id": "qr1", "r_idx": 0, "r_link": "1",   "f_idx": 1, "f_link": "2" },
+        { "id": "qr1", "r_idx": 1, "r_link": "1.1", "f_idx": 0, "f_link": "1" },
+        { "id": "qr1", "r_idx": 1, "r_link": "1.1", "f_idx": 1, "f_link": "2" },
+        { "id": "qr1", "r_idx": 2, "r_link": "1.2", "f_idx": 0, "f_link": "1" },
+        { "id": "qr1", "r_idx": 2, "r_link": "1.2", "f_idx": 1, "f_link": "2" },
+        { "id": "qr1", "r_idx": 3, "r_link": "2",   "f_idx": 0, "f_link": "1" },
+        { "id": "qr1", "r_idx": 3, "r_link": "2",   "f_idx": 1, "f_link": "2" },
+        { "id": "qr1", "r_idx": 4, "r_link": "2.1", "f_idx": 0, "f_link": "1" },
+        { "id": "qr1", "r_idx": 4, "r_link": "2.1", "f_idx": 1, "f_link": "2" },
+        { "id": "qr2", "r_idx": 0, "r_link": "A",   "f_idx": 0, "f_link": "A" },
+        { "id": "qr2", "r_idx": 0, "r_link": "A",   "f_idx": 1, "f_link": "B" },
+        { "id": "qr2", "r_idx": 1, "r_link": "A.1", "f_idx": 0, "f_link": "A" },
+        { "id": "qr2", "r_idx": 1, "r_link": "A.1", "f_idx": 1, "f_link": "B" },
+        { "id": "qr2", "r_idx": 2, "r_link": "B",   "f_idx": 0, "f_link": "A" },
+        { "id": "qr2", "r_idx": 2, "r_link": "B",   "f_idx": 1, "f_link": "B" }
+      ]
+    }
+  ]
+}

--- a/tests/staged-repeat.test.js
+++ b/tests/staged-repeat.test.js
@@ -142,11 +142,12 @@ describe("staged - fork inside a repeat body", () => {
 	});
 });
 
-// `%rowIndex` indexing a repeat's OWN descent scope is Stage 4 (the recursive CTE has no
-// per-iteration ordinal). It must be rejected at build time, not silently bound to a constant 0.
-// `%rowIndex` for a forEach/forEachOrNull *inside* a repeat body is Stage 2 and keeps working
-// (covered by the choice-type fixtures' iteration); this only guards the own-scope case.
-describe("staged - %rowIndex over a repeat's own scope is rejected", () => {
+// `%rowIndex` indexing a repeat's OWN descent scope is Stage 4: assigned by a pre-order window over
+// the descent path (NOT silently bound to a constant 0, and no longer rejected). The end-to-end
+// numbering is exercised by row_index_repeat.json; here we only assert the build compiles and emits
+// the pre-order window. A `%rowIndex` referencing a repeat scope that the emitter does NOT enter
+// (no descent) would still be rejected by the leaf engine — that guard remains in ddb-sql-builder.
+describe("staged - %rowIndex over a repeat's own scope is a pre-order window", () => {
 	const riView = {
 		resource: "QuestionnaireResponse",
 		select: [
@@ -157,11 +158,12 @@ describe("staged - %rowIndex over a repeat's own scope is rejected", () => {
 			]}
 		]
 	};
-	test("throws rather than emitting a constant", () => {
-		expect(() => templateToQuery(
+	test("emits a row_number() pre-order window partitioned per resource", () => {
+		const sql = templateToQuery(
 			riView, fhirSchema, stagedQueryTemplate,
 			[["test_file_path", "/tmp/unused.json"]], verbose, true, null, null, "natural"
-		)).toThrow(/%rowIndex/);
+		);
+		expect(sql).toMatch(/row_number\(\) OVER \(PARTITION BY rid ORDER BY path\)/);
 	});
 });
 


### PR DESCRIPTION
Closes #32. Final stage of the hybrid-emitter migration (parent #1).

## Problem
`%rowIndex` worked for `forEach`/`forEachOrNull` (Stage 2) and `repeat` descent worked (Stage 3), but `%rowIndex` indexing a `repeat`'s OWN descent scope was unimplemented — the leaf engine rejected it (`bridgeElem.rowIndexSql = null`). A `repeat` has no single parent collection, so it has no per-iteration ordinal to bind.

## Solution (SPEC_hybrid §11)
Assign the index at the repeat's own scope (one row per visited node) by a window over the int-list descent `path` the recursive CTE already carries, **before** any sibling recombination, then carry it as a scalar through joins:

`ROW_NUMBER() OVER (PARTITION BY {enclosing-scope key} ORDER BY path) - 1`

- **Root repeat** → `PARTITION BY rid`. `rid` is forced even in a fork-free view via `subtreeHasRepeatUsingRowIndex` (a per-resource partition is required so the index restarts per resource — `row_index.json` cannot catch this because it has a single resource).
- **Repeat under a forEach** → the enclosing forEach carries its iteration ordinal as a key (`f.needsOrd` now also true when a `%rowIndex` repeat is below), so the window restarts per enclosing element.
- **Repeat-in-repeat** → the inner window partitions by the outer repeat's own index (`(rid, outer_rn)`), never `PARTITION BY` a LIST.
- Ordering is by the `BIGINT[]` path element-wise (numeric), so it stays correct past 10 siblings.

The pre-order window **unifies** with the existing fork-recombination node key — same value, same `nord{N}` column — and is computed whenever any of {fork, this repeat's `%rowIndex`, a nested `%rowIndex` repeat} needs it. The window value is bound to `%rowIndex` (`usesRowIndex`) and/or carried as a body key (fork or nested-repeat surrogate).

Detection helpers `pathMentionsRowIndex` / `repeatScopeUsesRowIndex` / `subtreeHasRepeatUsingRowIndex` (structural look-ahead, over-approximating is safe) force the root key / carried ordinals; the precise per-scope binding (`scopeUsesRowIndex`) parses the resolved AST.

## Tests / Verification
- New `tests/spec-tests/row_index_repeat.json` (staged-only extended suite, `skip:true` so generic auto-discovery ignores it) + `tests/row-index-repeat.test.js` (dedicated runner, **natural + uuid** key modes). 5 cases × 2 modes.
- Updated the now-obsolete Stage 3 "rejected" guard into a positive pre-order-window assertion.
- `bun test`: **334 → 344 pass, 0 fail** (+10 from the new suite). Full prior suite green.
- End-to-end (`bun run ./src/cli.js --mode explore`):
  - root repeat: `qr1` indices `0,1,2,3,4` (1,1.1,1.2,2,2.1 in descent order), restarts `0,1,2` for `qr2`.
  - repeat-in-repeat: outer `0`(link 1)→inner `0,1`; outer `3`(link 2)→inner `0` — inner resets per outer node.

Stays on DuckDB 1.4.1 (`ROW_NUMBER()` window, `int[]` ordering, `list_append`).

This completes the hybrid-only (staged) migration: the struct emitter is fully gone and every directive — columns, forEach/forEachOrNull, unionAll, where, and repeat — plus `%rowIndex` across all of them is served by the single staged emitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)